### PR TITLE
Include ctime header in core/types.hpp.

### DIFF
--- a/includes/cpp_redis/core/types.hpp
+++ b/includes/cpp_redis/core/types.hpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <ctime>
 #include <chrono>
 #include <cpp_redis/core/reply.hpp>
 #include <functional>


### PR DESCRIPTION
When compiled using VS2017, it complaints that `std::time_t` is not a member of `std`. I checked the source code and find out that the `ctime` header is missing.