### PR TITLE
Fix return local variable warning

### DIFF
--- a/includes/cpp_redis/core/types.hpp
+++ b/includes/cpp_redis/core/types.hpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <ctime>
 #include <chrono>
 #include <cpp_redis/core/reply.hpp>
 #include <functional>

--- a/includes/cpp_redis/impl/types.hpp
+++ b/includes/cpp_redis/impl/types.hpp
@@ -130,7 +130,7 @@ namespace cpp_redis {
 				return m_values;
 			};
 
-			inline std::multimap<std::string, std::string> &get_str_values() const {
+			inline std::multimap<std::string, std::string> get_str_values() const {
 				std::multimap<std::string, std::string> ret;
 				for (auto &v : m_values) {
 					std::stringstream s;


### PR DESCRIPTION
I don't know why the local variable chosen to be returned. As the project needs `std::optional` which is included in c++17, I think move constructor and assignment will handle the performance, and no need to return a local variable as reference. It seems ok on VS but warning under gcc and clang.