### PR TITLE
Bugfix for C++17

### DIFF
--- a/includes/cpp_redis/core/reply.hpp
+++ b/includes/cpp_redis/core/reply.hpp
@@ -195,7 +195,7 @@ namespace cpp_redis {
 			explicit operator bool() const;
 
 	public:
-			optional<int64_t> try_get_int() const;
+			optional_t<int64_t> try_get_int() const;
 
 	public:
 /**

--- a/includes/cpp_redis/misc/convert.hpp
+++ b/includes/cpp_redis/misc/convert.hpp
@@ -30,12 +30,12 @@ namespace cpp_redis {
 	class try_convert {
 	public:
 			template <class T>
-			static enableIf<std::is_convertible<T, std::string>::value, optional<int64_t> > to_int(T value) {
+			static enableIf<std::is_convertible<T, std::string>::value, optional_t<int64_t> > to_int(T value) {
 				try {
 					std::stringstream stream(value);
 					int64_t x;
 					stream >> x;
-					return optional<int64_t>()(x);
+					return optional_t<int64_t>(x);
 				} catch (std::exception &exc) {
 					return {};
 				}

--- a/includes/cpp_redis/misc/optional.hpp
+++ b/includes/cpp_redis/misc/optional.hpp
@@ -28,8 +28,12 @@
 #if __cplusplus >= 201703L
 #include <optional>
 
+namespace cpp_redis {
 template <class T>
 using optional_t = std::optional<T>;
+
+template <int I, class T>
+using enableIf = typename std::enable_if<I, T>::type;
 #else
 
 #include <cpp_redis/misc/logger.hpp>
@@ -40,11 +44,12 @@ using enableIf = typename std::enable_if<I, T>::type;
 
 template <class T>
 struct optional {
-  optional<T>&
-  operator()(T value) {
-    m_value = value;
-    return *this;
-  }
+  optional(T value) : m_value(value) {}
+//  optional<T>&
+//  operator()(T value) {
+//    m_value = value;
+//    return *this;
+//  }
 
   T m_value;
 

--- a/sources/core/reply.cpp
+++ b/sources/core/reply.cpp
@@ -22,6 +22,7 @@
 
 #include <cpp_redis/core/reply.hpp>
 #include <cpp_redis/misc/error.hpp>
+#include <cpp_redis/misc/logger.hpp>
 
 namespace cpp_redis {
 
@@ -45,12 +46,12 @@ namespace cpp_redis {
 		m_int_val = other.m_int_val;
 	}
 
-	optional<int64_t> reply::try_get_int() const {
+	optional_t<int64_t> reply::try_get_int() const {
 		if (is_integer())
-			return optional<int64_t>()(m_int_val);
+			return optional_t<int64_t>()(m_int_val);
 
-			__CPP_REDIS_LOG(1, "Reply is not an integer");
-			return {};
+		__CPP_REDIS_LOG(1, "Reply is not an integer");
+		return {0};
 	}
 
 	reply &


### PR DESCRIPTION
Bracket operator of struct 'optional' has been replaced with a
standard constructor. logger.hpp inclusion in reply.cpp. Change of
optional to optional_t where struct used. enableIf template added
to C++ branching in optional.hpp