### PR TITLE
Fix never-returning xreadgroup case in example

### DIFF
--- a/examples/cpp_redis_client.cpp
+++ b/examples/cpp_redis_client.cpp
@@ -70,7 +70,7 @@ main(void) {
 #ifdef ENABLE_SESSION
 
 	client.xadd(session_name, "*", ins, replcmd);
-	client.xgroup_create(session_name, group_name, replcmd);
+	client.xgroup_create(session_name, group_name, "0", replcmd);
 
 	client.sync_commit();
 


### PR DESCRIPTION
By default `XGROUP CREATE` passes `$` as the ID which means "serve all IDs added from this point on".

Due to that, the `XADD` directly above never gets served to the `XREADGROUP` command and this example will just hang the first time you run it waiting.

Adding an explicit ID of 0 means we will get the previous message back in the `XREADGROUP`.