### PR TITLE
support mingw-gcc on WIN platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if (MSVC OR WIN32)
 	add_definitions(-DWIN32_LEAN_AND_MEAN)
 else ()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -W -Wall -Wextra -O3")
-endif (MSVC)
+endif ()
 
 
 ###

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ project(${PROJECT} CXX)
 ###
 # compilation options
 ###
-if (WIN32)
+if (MSVC)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /O2 /bigobj")
 
 	# was causing conflics with gtest build
@@ -70,7 +70,7 @@ if (WIN32)
 	add_definitions(-DWIN32_LEAN_AND_MEAN)
 else ()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -W -Wall -Wextra -O3")
-endif (WIN32)
+endif (MSVC)
 
 
 ###

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ project(${PROJECT} CXX)
 ###
 # compilation options
 ###
-if (MSVC)
+if (MSVC OR WIN32)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /O2 /bigobj")
 
 	# was causing conflics with gtest build


### PR DESCRIPTION
1. to support mingw-gcc on WIN platform
2. and the link of "tacopie @ 8714fce" should change to "https://github.com/Cylix/tacopie/tree/5b60d9a9e87aa4ba8118a66f6d65eb15ab0c8769"
3. the compile command: cmake -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX=YOUR:\PATH\cpp_redis . && mingw32-make install