### PR TITLE
client::re_auth submits 2 AUTH commands upon reconnect, expects only one response

### DIFF
--- a/includes/cpp_redis/core/client.hpp
+++ b/includes/cpp_redis/core/client.hpp
@@ -1151,9 +1151,9 @@ namespace cpp_redis {
 			std::future<reply> ping(const std::string &message);
 
 			client &
-			psetex(const std::string &key, int ms, const std::string &val, const reply_callback_t &reply_callback);
+			psetex(const std::string &key, int64_t ms, const std::string &val, const reply_callback_t &reply_callback);
 
-			std::future<reply> psetex(const std::string &key, int ms, const std::string &val);
+			std::future<reply> psetex(const std::string &key, int64_t ms, const std::string &val);
 
 			client &publish(const std::string &channel, const std::string &message, const reply_callback_t &reply_callback);
 
@@ -1307,9 +1307,9 @@ namespace cpp_redis {
 			std::future<reply> setbit_(const std::string &key, int offset, const std::string &value);
 
 			client &
-			setex(const std::string &key, int seconds, const std::string &value, const reply_callback_t &reply_callback);
+			setex(const std::string &key, int64_t seconds, const std::string &value, const reply_callback_t &reply_callback);
 
-			std::future<reply> setex(const std::string &key, int seconds, const std::string &value);
+			std::future<reply> setex(const std::string &key, int64_t seconds, const std::string &value);
 
 			client &setnx(const std::string &key, const std::string &value, const reply_callback_t &reply_callback);
 

--- a/sources/core/client.cpp
+++ b/sources/core/client.cpp
@@ -1694,7 +1694,7 @@ namespace cpp_redis {
 	}
 
 	client &
-	client::psetex(const std::string &key, int ms, const std::string &val,
+	client::psetex(const std::string &key, int64_t ms, const std::string &val,
 	               const reply_callback_t &reply_callback) {
 		send({"PSETEX", key, std::to_string(ms), val}, reply_callback);
 		return *this;
@@ -1967,7 +1967,7 @@ namespace cpp_redis {
 	}
 
 	client &
-	client::setex(const std::string &key, int seconds, const std::string &value, const reply_callback_t &reply_callback) {
+	client::setex(const std::string &key, int64_t seconds, const std::string &value, const reply_callback_t &reply_callback) {
 		send({"SETEX", key, std::to_string(seconds), value}, reply_callback);
 		return *this;
 	}
@@ -4020,7 +4020,7 @@ namespace cpp_redis {
 	}
 
 	std::future<reply>
-	client::psetex(const std::string &key, int ms, const std::string &val) {
+	client::psetex(const std::string &key, int64_t ms, const std::string &val) {
 		return exec_cmd([=](const reply_callback_t &cb) -> client & { return psetex(key, ms, val, cb); });
 	}
 
@@ -4199,7 +4199,7 @@ namespace cpp_redis {
 	}
 
 	std::future<reply>
-	client::setex(const std::string &key, int seconds, const std::string &value) {
+	client::setex(const std::string &key, int64_t seconds, const std::string &value) {
 		return exec_cmd([=](const reply_callback_t &cb) -> client & { return setex(key, seconds, value, cb); });
 	}
 


### PR DESCRIPTION
If we lose the TCP connection for the cpp_redis::client and it is then reconnected, there was a problem were the AUTH command got serialized twice to the buffer to be sent to the TCP connection by unprotected_auth:
  Once when it was directly added to the buffer AND
  Once because it was added to the command queue it got serialize to the buffer again
However there was only one callback on the command queue.  This means we got 2 responses and only
one callback to handle them.  So the next command in the queue gets the second AUTH response
instead of the expected response and everything is off by one.