### PR TITLE
Add support for CLIENT SETNAME command to cpp_redis::Subscriber

### DIFF
--- a/includes/cpp_redis/core/client.hpp
+++ b/includes/cpp_redis/core/client.hpp
@@ -1151,9 +1151,9 @@ namespace cpp_redis {
 			std::future<reply> ping(const std::string &message);
 
 			client &
-			psetex(const std::string &key, int ms, const std::string &val, const reply_callback_t &reply_callback);
+			psetex(const std::string &key, int64_t ms, const std::string &val, const reply_callback_t &reply_callback);
 
-			std::future<reply> psetex(const std::string &key, int ms, const std::string &val);
+			std::future<reply> psetex(const std::string &key, int64_t ms, const std::string &val);
 
 			client &publish(const std::string &channel, const std::string &message, const reply_callback_t &reply_callback);
 
@@ -1307,9 +1307,9 @@ namespace cpp_redis {
 			std::future<reply> setbit_(const std::string &key, int offset, const std::string &value);
 
 			client &
-			setex(const std::string &key, int seconds, const std::string &value, const reply_callback_t &reply_callback);
+			setex(const std::string &key, int64_t seconds, const std::string &value, const reply_callback_t &reply_callback);
 
-			std::future<reply> setex(const std::string &key, int seconds, const std::string &value);
+			std::future<reply> setex(const std::string &key, int64_t seconds, const std::string &value);
 
 			client &setnx(const std::string &key, const std::string &value, const reply_callback_t &reply_callback);
 

--- a/includes/cpp_redis/core/subscriber.hpp
+++ b/includes/cpp_redis/core/subscriber.hpp
@@ -161,6 +161,16 @@ namespace cpp_redis {
 			subscriber &auth(const std::string &password, const reply_callback_t &reply_callback = nullptr);
 
 /**
+ * @brief Set the label for the connection on the Redis server via the CLIENT SETNAME command.
+ * This is useful for monitoring and managing connections on the server side of things.
+ * @param name - string to label the connection with on the server side
+ * @param reply_callback callback to be called on auth completion (nullable)
+ * @return current instance
+ *
+ */
+			subscriber& client_setname(const std::string& name, const reply_callback_t& reply_callback = nullptr);
+
+/**
  * subscribe callback, called whenever a new message is published on a subscribed channel
  * takes as parameter the channel and the message
  *
@@ -343,6 +353,12 @@ namespace cpp_redis {
 			void re_auth();
 
 /**
+ * re send CLIENT SETNAME to redis server based on previously used name
+ *
+ */
+			void re_client_setname(void);
+
+/**
  * resubscribe (sub and psub) to previously subscribed channels/patterns
  *
  */
@@ -412,6 +428,12 @@ namespace cpp_redis {
  *
  */
 			std::string m_password;
+
+/**
+ * name to use with CLIENT SETNAME
+ *
+ */
+			std::string m_client_name;
 
 /**
  * tcp client for redis connection
@@ -490,6 +512,12 @@ namespace cpp_redis {
  *
  */
 			reply_callback_t m_auth_reply_callback;
+
+/**
+ * client setname reply callback
+ *
+ */
+			reply_callback_t m_client_setname_reply_callback;
 	};
 
 } // namespace cpp_redis

--- a/sources/core/client.cpp
+++ b/sources/core/client.cpp
@@ -1694,7 +1694,7 @@ namespace cpp_redis {
 	}
 
 	client &
-	client::psetex(const std::string &key, int ms, const std::string &val,
+	client::psetex(const std::string &key, int64_t ms, const std::string &val,
 	               const reply_callback_t &reply_callback) {
 		send({"PSETEX", key, std::to_string(ms), val}, reply_callback);
 		return *this;
@@ -1967,7 +1967,7 @@ namespace cpp_redis {
 	}
 
 	client &
-	client::setex(const std::string &key, int seconds, const std::string &value, const reply_callback_t &reply_callback) {
+	client::setex(const std::string &key, int64_t seconds, const std::string &value, const reply_callback_t &reply_callback) {
 		send({"SETEX", key, std::to_string(seconds), value}, reply_callback);
 		return *this;
 	}
@@ -4020,7 +4020,7 @@ namespace cpp_redis {
 	}
 
 	std::future<reply>
-	client::psetex(const std::string &key, int ms, const std::string &val) {
+	client::psetex(const std::string &key, int64_t ms, const std::string &val) {
 		return exec_cmd([=](const reply_callback_t &cb) -> client & { return psetex(key, ms, val, cb); });
 	}
 
@@ -4199,7 +4199,7 @@ namespace cpp_redis {
 	}
 
 	std::future<reply>
-	client::setex(const std::string &key, int seconds, const std::string &value) {
+	client::setex(const std::string &key, int64_t seconds, const std::string &value) {
 		return exec_cmd([=](const reply_callback_t &cb) -> client & { return setex(key, seconds, value, cb); });
 	}
 

--- a/sources/core/subscriber.cpp
+++ b/sources/core/subscriber.cpp
@@ -32,7 +32,8 @@ namespace cpp_redis {
 subscriber::subscriber()
 : m_reconnecting(false)
 , m_cancel(false)
-, m_auth_reply_callback(nullptr) {
+, m_auth_reply_callback(nullptr)
+, m_client_setname_reply_callback(nullptr) {
   __CPP_REDIS_LOG(debug, "cpp_redis::subscriber created");
 }
 #endif /* __CPP_REDIS_USE_CUSTOM_TCP_CLIENT */
@@ -154,6 +155,24 @@ subscriber::auth(const std::string& password, const reply_callback_t& reply_call
   m_client.send({"AUTH", password});
 
   __CPP_REDIS_LOG(info, "cpp_redis::subscriber AUTH command sent");
+
+  return *this;
+}
+
+subscriber&
+subscriber::client_setname(const std::string& name, const reply_callback_t& reply_callback) {
+  __CPP_REDIS_LOG(debug, "cpp_redis::subscriber attempts to send CLIENT SETNAME");
+
+  // Retain the name as CLIENT SETNAME can only be sent between the reAUTH and reSUBSCRIBE
+  // commands on reconnecting.  This makes it impossible to do reliably in the application
+  // layer as opposed to in the subscriber itself for reconnects.  re_client_setname will
+  // send the command at reconnect time.
+  m_client_name = name;
+  m_client_setname_reply_callback = reply_callback;
+
+  m_client.send({"CLIENT", "SETNAME", name});
+
+  __CPP_REDIS_LOG(info, "cpp_redis::subscriber CLIENT SETNAME command sent");
 
   return *this;
 }
@@ -364,6 +383,12 @@ subscriber::connection_receive_handler(network::redis_connection&, reply& reply)
       m_auth_reply_callback(reply);
       m_auth_reply_callback = nullptr;
     }
+    else if (m_client_setname_reply_callback) {
+      __CPP_REDIS_LOG(debug, "cpp_redis::subscriber executes client setname callback");
+
+      m_client_setname_reply_callback(reply);
+      m_client_setname_reply_callback = nullptr;
+    }
 
     return;
   }
@@ -480,6 +505,10 @@ subscriber::reconnect() {
   __CPP_REDIS_LOG(info, "client reconnected ok");
 
   re_auth();
+  // This is the only window that the Redis server will let us send the CLIENT SETNAME
+  // (i.e. between the re_auth and the re_subscriber).  So this needs to be done
+  // by the subscriber as opposed to the application layer for reconnects.
+  re_client_setname();
   re_subscribe();
   commit();
 }
@@ -510,6 +539,22 @@ subscriber::re_auth() {
     }
     else {
       __CPP_REDIS_LOG(warn, std::string("subscriber failed to re-authenticate: " + reply.as_string()).c_str());
+    }
+  });
+}
+
+void
+subscriber::re_client_setname(void) {
+  if (m_client_name.empty()) {
+    return;
+  }
+
+  client_setname(m_client_name, [&](cpp_redis::reply& reply) {
+    if (reply.is_string() && reply.as_string() == "OK") {
+      __CPP_REDIS_LOG(warn, "subscriber successfully re-sent client setname");
+    }
+    else {
+      __CPP_REDIS_LOG(warn, std::string("subscriber failed to re-send client setname: " + reply.as_string()).c_str());
     }
   });
 }


### PR DESCRIPTION
Add the ability to send the CLIENT SETNAME command to label the subscriber client connection on the server side.  This is useful for debugging and management from the server side of things, particularly when you have a large number of connections.

The CLIENT command must be sent after the AUTH (if used) and before the first SUBSCRIBE command is sent or the Redis server will issue an error.   In order for this to work after a reconnect, the subscriber needs to manage the re-issuing of the CLIENT SETNAME command to be sure it is sent after re_auth and before the re_subscribe occurs.