### PR TITLE
Make eval api simpler

### DIFF
--- a/includes/cpp_redis/core/client.hpp
+++ b/includes/cpp_redis/core/client.hpp
@@ -39,6 +39,7 @@
 #include <cpp_redis/misc/logger.hpp>
 #include <cpp_redis/network/redis_connection.hpp>
 #include <cpp_redis/network/tcp_client_iface.hpp>
+#include <cpp_redis/misc/deprecated.hpp>
 
 namespace cpp_redis {
 
@@ -779,16 +780,28 @@ namespace cpp_redis {
 
 			std::future<reply> echo(const std::string &msg);
 
-			client &eval(const std::string &script, int numkeys, const std::vector<std::string> &keys,
+			client &eval(const std::string &script, const std::vector<std::string> &keys,
 			             const std::vector<std::string> &args, const reply_callback_t &reply_callback);
 
-			std::future<reply> eval(const std::string &script, int numkeys, const std::vector<std::string> &keys,
+			DEPRECATED client &eval(const std::string &script, int numkeys, const std::vector<std::string> &keys,
+			             const std::vector<std::string> &args, const reply_callback_t &reply_callback);
+
+			std::future<reply> eval(const std::string &script, const std::vector<std::string> &keys,
 			                        const std::vector<std::string> &args);
 
-			client &evalsha(const std::string &sha1, int numkeys, const std::vector<std::string> &keys,
+			DEPRECATED std::future<reply> eval(const std::string &script, int numkeys, const std::vector<std::string> &keys,
+			                        const std::vector<std::string> &args);
+
+			client &evalsha(const std::string &sha1, const std::vector<std::string> &keys,
 			                const std::vector<std::string> &args, const reply_callback_t &reply_callback);
 
-			std::future<reply> evalsha(const std::string &sha1, int numkeys, const std::vector<std::string> &keys,
+			DEPRECATED client &evalsha(const std::string &sha1, int numkeys, const std::vector<std::string> &keys,
+			                const std::vector<std::string> &args, const reply_callback_t &reply_callback);
+
+			std::future<reply> evalsha(const std::string &sha1, const std::vector<std::string> &keys,
+			                           const std::vector<std::string> &args);
+
+			DEPRECATED std::future<reply> evalsha(const std::string &sha1, int numkeys, const std::vector<std::string> &keys,
 			                           const std::vector<std::string> &args);
 
 			client &exec(const reply_callback_t &reply_callback);

--- a/includes/cpp_redis/misc/deprecated.hpp
+++ b/includes/cpp_redis/misc/deprecated.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#if defined(__GNUC__) || defined(__clang__)
+#define DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#define DEPRECATED __declspec(deprecated)
+#else
+#pragma message("WARNING: You need to implement DEPRECATED for this compiler")
+#define DEPRECATED
+#endif

--- a/sources/core/client.cpp
+++ b/sources/core/client.cpp
@@ -1004,9 +1004,29 @@ namespace cpp_redis {
 	}
 
 	client &
+	client::eval(const std::string &script, const std::vector<std::string> &keys,
+	             const std::vector<std::string> &args, const reply_callback_t &reply_callback) {
+		std::vector<std::string> cmd = {"EVAL", script, std::to_string(keys.size())};
+		cmd.insert(cmd.end(), keys.begin(), keys.end());
+		cmd.insert(cmd.end(), args.begin(), args.end());
+		send(cmd, reply_callback);
+		return *this;
+	}
+
+	client &
 	client::evalsha(const std::string &sha1, int numkeys, const std::vector<std::string> &keys,
 	                const std::vector<std::string> &args, const reply_callback_t &reply_callback) {
 		std::vector<std::string> cmd = {"EVALSHA", sha1, std::to_string(numkeys)};
+		cmd.insert(cmd.end(), keys.begin(), keys.end());
+		cmd.insert(cmd.end(), args.begin(), args.end());
+		send(cmd, reply_callback);
+		return *this;
+	}
+
+	client &
+	client::evalsha(const std::string &sha1, const std::vector<std::string> &keys,
+	                const std::vector<std::string> &args, const reply_callback_t &reply_callback) {
+		std::vector<std::string> cmd = {"EVALSHA", sha1, std::to_string(keys.size())};
 		cmd.insert(cmd.end(), keys.begin(), keys.end());
 		cmd.insert(cmd.end(), args.begin(), args.end());
 		send(cmd, reply_callback);
@@ -3671,13 +3691,27 @@ namespace cpp_redis {
 	std::future<reply>
 	client::eval(const std::string &script, int numkeys, const std::vector<std::string> &keys,
 	             const std::vector<std::string> &args) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return eval(script, numkeys, keys, args, cb); });
+		(void) numkeys;
+		return exec_cmd([=](const reply_callback_t &cb) -> client & { return eval(script, keys, args, cb); });
+	}
+
+	std::future<reply>
+	client::eval(const std::string &script, const std::vector<std::string> &keys,
+	             const std::vector<std::string> &args) {
+		return exec_cmd([=](const reply_callback_t &cb) -> client & { return eval(script, keys, args, cb); });
+	}
+
+	std::future<reply>
+	client::evalsha(const std::string &sha1, const std::vector<std::string> &keys,
+	                const std::vector<std::string> &args) {
+		return exec_cmd([=](const reply_callback_t &cb) -> client & { return evalsha(sha1, keys, args, cb); });
 	}
 
 	std::future<reply>
 	client::evalsha(const std::string &sha1, int numkeys, const std::vector<std::string> &keys,
 	                const std::vector<std::string> &args) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return evalsha(sha1, numkeys, keys, args, cb); });
+		(void) numkeys;
+		return exec_cmd([=](const reply_callback_t &cb) -> client & { return evalsha(sha1, keys, args, cb); });
 	}
 
 	std::future<reply>


### PR DESCRIPTION
The `numkeys` argument is redundant here, just remove it.

Maybe we need to add a api like this from [jedis](https://static.javadoc.io/redis.clients/jedis/2.9.0/redis/clients/jedis/Jedis.html#eval-java.lang.String-int-java.lang.String...-):
```
public Object eval(String script,
                   int keyCount,
                   String... params)
Specified by:
eval in interface ScriptingCommands
```