### PR TITLE
Base classes should have virtual destructors

### DIFF
--- a/includes/cpp_redis/impl/types.hpp
+++ b/includes/cpp_redis/impl/types.hpp
@@ -40,6 +40,8 @@ namespace cpp_redis {
 class serializer_type {
 public:
   inline serializer_type() {}
+  
+  virtual ~serializer_type() {}
 
   /**
  * @return the underlying string
@@ -62,6 +64,8 @@ typedef std::shared_ptr<serializer_type> serializer_ptr_t;
 template <typename T>
 class message_impl {
 public:
+  virtual ~message_impl() {}
+
   virtual const std::string get_id() const = 0;
 
   virtual const message_impl& set_id(std::string id) = 0;


### PR DESCRIPTION
From https://en.cppreference.com/w/cpp/language/destructor ...

Virtual destructors
Deleting an object through pointer to base invokes undefined behavior unless the destructor in the base class is virtual:
class Base {
 public:
    virtual ~Base() {}
};
class Derived : public Base {};
Base* b = new Derived;
delete b; // safe
A common guideline is that a destructor for a base class must be either public and virtual or protected and nonvirtual

Prevents errors like the following:
INFO: From Compiling external/com_github_cpp_redis_cpp_redis/sources/core/types.cpp:
In file included from external/com_github_cpp_redis_cpp_redis/sources/core/types.cpp:23:
In file included from bazel-out/darwin-fastbuild/bin/external/com_github_cpp_redis_cpp_redis/_virtual_includes/cpp_redis/cpp_redis/core/types.hpp:26:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/string:500:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/string_view:176:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/__string:56:
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/algorithm:644:
/Library/Developer/CommandLineTools/usr/include/c++/v1/memory:1880:58: warning: destructor called on non-final 'cpp_redis::xmessage' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
    _LIBCPP_INLINE_VISIBILITY void destroy(pointer __p) {__p->~_Tp();}
                                                         ^