### PR TITLE
Update README for new links to cpp-redis wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ client.sync_commit();
 //! or client.commit(); for asynchronous call
 ```
 
-`cpp_redis::client` [full documentation](https://github.com/Cylix/cpp_redis/wiki/Redis-Client) and [detailed example](https://github.com/Cylix/cpp_redis/wiki/Examples#redis-client).
-More about [cpp_redis::reply](https://github.com/Cylix/cpp_redis/wiki/Replies).
+`cpp_redis::client` [full documentation](https://github.com/cpp-redis/cpp_redis/wiki/Redis-Client) and [detailed example](https://github.com/cpp-redis/cpp_redis/wiki/Examples#redis-client).
+More about [cpp_redis::reply](https://github.com/cpp-redis/cpp_redis/wiki/Replies).
 
 ### cpp_redis::subscriber
 
@@ -53,11 +53,11 @@ sub.commit();
 
 ```
 
-`cpp_redis::subscriber` [full documentation](https://github.com/Cylix/cpp_redis/wiki/Redis-Subscriber) and [detailed example](https://github.com/Cylix/cpp_redis/wiki/Examples#redis-subscriber).
+`cpp_redis::subscriber` [full documentation](https://github.com/cpp-redis/cpp_redis/wiki/Redis-Subscriber) and [detailed example](https://github.com/cpp-redis/cpp_redis/wiki/Examples#redis-subscriber).
 
 ## Wiki
 
-A [Wiki](https://github.com/Cylix/cpp_redis/wiki) is available and provides full documentation for the library as well as [installation explanations](https://github.com/Cylix/cpp_redis/wiki/Installation).
+A [Wiki](https://github.com/cpp-redis/cpp_redis/wiki) is available and provides full documentation for the library as well as [installation explanations](https://github.com/cpp-redis/cpp_redis/wiki/Installation).
 
 # Doxygen
 


### PR DESCRIPTION
Hiya!

Just a quick proposal to link to the wiki on here, rather than at the old Cylix repo.

If this isn't appreciated, let me know! I was just building & installing and noticed the disparity, so I figured I'd go ahead and PR.

Thanks!