### PR TITLE
Add a function to declare tacopie dependency

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,0 +1,12 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+cpp_redis_repositories:
+  """Add external dependencies to the workspace."""
+  maybe(
+    http_archive,
+    name = "tacopie",
+    urls = ["https://github.com/cylix/tacopie/archive/6b060c7f7e158e60d634c14e412aa78d4041f237.tar.gz"],
+    strip_prefix = "tacopie-6b060c7f7e158e60d634c14e412aa78d4041f237",
+    sha256 = "6e123b274480476d1a9bab675623519ccd3108ee93a0515823a70a471a93aff8",
+  )


### PR DESCRIPTION
Typically, Bazel-aware third-party libraries provide a function that can be called from a WORKSPACE to add the library's dependencies. By doing this, cpp_redis can be declared like so:

http_archive(
    name = "com_github_cpp_redis_cpp_redis",
    urls = ["https://github.com/cpp-redis/cpp_redis/archive/147c589b239cee8521a7fdb827c98f3e8cc3c897.tar.gz"],
    strip_prefix = "cpp_redis-147c589b239cee8521a7fdb827c98f3e8cc3c897",
    sha256 = "2c72ae0466495124facba23e5e79b9f1df539e1c8dc025115cd7ba76d14676a1",
)

load("@com_github_cpp_redis_cpp_redis//:repositories.bzl", "cpp_redis_repositories")
cpp_redis_repositories()