### PR TITLE
Fixed Logging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON
 make
 # Run tests and examples
 ctest -VV
-./bin/subscriber
-./bin/client
+./bin/cpp_redis_subscriber
+./bin/cpp_redis_client
 ```
 
 ## 5. Code your changes

--- a/clang_format.sh
+++ b/clang_format.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-find sources includes tests examples \( -name '*.cpp' -o -name '*.hpp' -o -name '*.ipp' -o -name '*.c' -o -name '*.h' \) -exec clang-format -i {} ';'
+find sources includes tests examples \( -name '*.cpp' -o -name '*.hpp' -o -name '*.ipp' -o -name '*.c' -o -name '*.h' \) -exec clang-format -style=file -fallback-style=none -i {} ';'

--- a/examples/cpp_redis_client.cpp
+++ b/examples/cpp_redis_client.cpp
@@ -19,97 +19,99 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-#include <string>
+#include "winsock_initializer.h"
 #include <cpp_redis/cpp_redis>
 #include <cpp_redis/misc/macro.hpp>
-#include "winsock_initializer.h"
+#include <string>
 
 #define ENABLE_SESSION = 1
 
 int
 main(void) {
-	winsock_initializer winsock_init;
-	//! Enable logging
-	cpp_redis::active_logger = std::unique_ptr<cpp_redis::logger>(new cpp_redis::logger);
+  winsock_initializer winsock_init;
+  //! Enable logging
+  cpp_redis::active_logger = std::unique_ptr<cpp_redis::logger>(new cpp_redis::logger);
 
-	cpp_redis::client client;
+  cpp_redis::client client;
 
-	client.connect("127.0.0.1", 6379,
-	               [](const std::string &host, std::size_t port, cpp_redis::connect_state status) {
-			               if (status == cpp_redis::connect_state::dropped) {
-				               std::cout << "client disconnected from " << host << ":" << port << std::endl;
-			               }
-	               });
+  client.connect("127.0.0.1", 6379,
+    [](const std::string& host, std::size_t port, cpp_redis::connect_state status) {
+      if (status == cpp_redis::connect_state::dropped) {
+        std::cout << "client disconnected from " << host << ":" << port << std::endl;
+      }
+    });
 
-	auto replcmd = [](const cpp_redis::reply &reply) {
-			std::cout << "set hello 42: " << reply << std::endl;
-			// if (reply.is_string())
-			//   do_something_with_string(reply.as_string())
-	};
+  auto replcmd = [](const cpp_redis::reply& reply) {
+    std::cout << "set hello 42: " << reply << std::endl;
+    // if (reply.is_string())
+    //   do_something_with_string(reply.as_string())
+  };
 
-	const std::string group_name = "groupone";
-	const std::string session_name = "sessone";
-	const std::string consumer_name = "ABCD";
+  const std::string group_name    = "groupone";
+  const std::string session_name  = "sessone";
+  const std::string consumer_name = "ABCD";
 
-	std::multimap<std::string, std::string> ins;
-	ins.insert(std::pair<std::string, std::string>{"message", "hello"});
+  std::multimap<std::string, std::string> ins;
+  ins.insert(std::pair<std::string, std::string>{"message", "hello"});
 
 #ifdef ENABLE_SESSION
 
-	client.xadd(session_name, "*", ins, replcmd);
-	client.xgroup_create(session_name, group_name, "0", replcmd);
+  client.xadd(session_name, "*", ins, replcmd);
+  client.xgroup_create(session_name, group_name, "0", replcmd);
 
-	client.sync_commit();
+  client.sync_commit();
 
-	client.xrange(session_name, {"-", "+", 10}, replcmd);
+  client.xrange(session_name, {"-", "+", 10}, replcmd);
 
-	client.xreadgroup({group_name,
-	                   consumer_name,
-	                   {{session_name}, {">"}},
-	                   1, // Count
-	                   0, // block milli
-	                   false, // no ack
-	                  }, [](cpp_redis::reply &reply) {
-			std::cout << "set hello 42: " << reply << std::endl;
-			auto msg = reply.as_array();
-			std::cout << "Mes: " << msg[0] << std::endl;
-			// if (reply.is_string())
-			//   do_something_with_string(reply.as_string())
-	});
+  client.xreadgroup({
+                      group_name,
+                      consumer_name,
+                      {{session_name}, {">"}},
+                      1,     // Count
+                      0,     // block milli
+                      false, // no ack
+                    },
+    [](cpp_redis::reply& reply) {
+      std::cout << "set hello 42: " << reply << std::endl;
+      auto msg = reply.as_array();
+      std::cout << "Mes: " << msg[0] << std::endl;
+      // if (reply.is_string())
+      //   do_something_with_string(reply.as_string())
+    });
 
 #else
 
-	// same as client.send({ "SET", "hello", "42" }, ...)
-	client.set("hello", "42", [](cpp_redis::reply &reply) {
-			std::cout << "set hello 42: " << reply << std::endl;
-			// if (reply.is_string())
-			//   do_something_with_string(reply.as_string())
-	});
+  // same as client.send({ "SET", "hello", "42" }, ...)
+  client.set("hello", "42", [](cpp_redis::reply& reply) {
+    std::cout << "set hello 42: " << reply << std::endl;
+    // if (reply.is_string())
+    //   do_something_with_string(reply.as_string())
+  });
 
-	// same as client.send({ "DECRBY", "hello", 12 }, ...)
-	client.decrby("hello", 12, [](cpp_redis::reply &reply) {
-			std::cout << "decrby hello 12: " << reply << std::endl;
-			// if (reply.is_integer())
-			//   do_something_with_integer(reply.as_integer())
-	});
+  // same as client.send({ "DECRBY", "hello", 12 }, ...)
+  client.decrby("hello", 12, [](cpp_redis::reply& reply) {
+    std::cout << "decrby hello 12: " << reply << std::endl;
+    // if (reply.is_integer())
+    //   do_something_with_integer(reply.as_integer())
+  });
 
-	// same as client.send({ "GET", "hello" }, ...)
-	client.get("hello", [](cpp_redis::reply &reply) {
-			std::cout << "get hello: " << reply << std::endl;
-			// if (reply.is_string())
-			//   do_something_with_string(reply.as_string())
-	});
+  // same as client.send({ "GET", "hello" }, ...)
+  client.get("hello", [](cpp_redis::reply& reply) {
+    std::cout << "get hello: " << reply << std::endl;
+    // if (reply.is_string())
+    //   do_something_with_string(reply.as_string())
+  });
 
 #endif
 
-	// commands are pipelined and only sent when client.commit() is called
-	// client.commit();
+  // commands are pipelined and only sent when client.commit() is called
+  // client.commit();
 
-	// synchronous commit, no timeout
-	client.sync_commit();
+  // synchronous commit, no timeout
+  client.sync_commit();
 
-	// synchronous commit, timeout
-	// client.sync_commit(std::chrono::milliseconds(100));
+  // synchronous commit, timeout
+  // client.sync_commit(std::chrono::milliseconds(100));
 
-	return 0;
+  return 0;
 }

--- a/examples/cpp_redis_consumer.cpp
+++ b/examples/cpp_redis_consumer.cpp
@@ -19,64 +19,64 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-#include <string>
 #include <condition_variable>
 #include <iostream>
 #include <mutex>
 #include <signal.h>
+#include <string>
 
-#include <cpp_redis/cpp_redis>
 #include "winsock_initializer.h"
+#include <cpp_redis/cpp_redis>
 
 std::condition_variable should_exit;
 
 void
 sigint_handler(int) {
-	should_exit.notify_all();
+  should_exit.notify_all();
 }
 
 int
 main() {
-	winsock_initializer winsock_init;
-	//! Enable logging
+  winsock_initializer winsock_init;
+  //! Enable logging
 
-	//const std::string group_name = "groupone";
-	const std::vector<std::string> group_names = {"groupone"}; //, "grouptwo"};
-	const std::string session_name = "sessone";
-	const std::string consumer_name = "ABCD";
+  //const std::string group_name = "groupone";
+  const std::vector<std::string> group_names = {"groupone"}; //, "grouptwo"};
+  const std::string session_name             = "sessone";
+  const std::string consumer_name            = "ABCD";
 
-	cpp_redis::active_logger = std::unique_ptr<cpp_redis::logger>(new cpp_redis::logger);
+  cpp_redis::active_logger = std::unique_ptr<cpp_redis::logger>(new cpp_redis::logger);
 
-	cpp_redis::consumer sub(session_name, consumer_name);
+  cpp_redis::consumer sub(session_name, consumer_name);
 
-	sub.connect("127.0.0.1", 6379,
-	            [](const std::string &host, std::size_t port, cpp_redis::connect_state status) {
-			            if (status == cpp_redis::connect_state::dropped) {
-				            std::cout << "client disconnected from " << host << ":" << port << std::endl;
-			            }
-	            });
+  sub.connect("127.0.0.1", 6379,
+    [](const std::string& host, std::size_t port, cpp_redis::connect_state status) {
+      if (status == cpp_redis::connect_state::dropped) {
+        std::cout << "client disconnected from " << host << ":" << port << std::endl;
+      }
+    });
 
-	sub.auth("{redis_key}");
+  sub.auth("{redis_key}");
 
-	for (auto &group : group_names) {
+  for (auto& group : group_names) {
 
-		sub.subscribe(group,
-		              [group](const cpp_redis::message_type msg) {
-											cpp_redis::consumer_response_t res;
-				              // Callback will run for each message obtained from the queue
-				              std::cout << "Group: " << group << std::endl;
-				              std::cout << "Id in the cb: " << msg.get_id() << std::endl;
-				              res.insert({"Id", msg.get_id()});
-				              return res;
-		              },
-		              [group](int ack_status) {
-				              // Callback will run upon return of xack
-				              std::cout << "Group: " << group << std::endl;
-				              std::cout << "Ack status: " << ack_status << std::endl;
-		              });
-	}
+    sub.subscribe(group,
+      [group](const cpp_redis::message_type msg) {
+        cpp_redis::consumer_response_t res;
+        // Callback will run for each message obtained from the queue
+        std::cout << "Group: " << group << std::endl;
+        std::cout << "Id in the cb: " << msg.get_id() << std::endl;
+        res.insert({"Id", msg.get_id()});
+        return res;
+      },
+      [group](int ack_status) {
+        // Callback will run upon return of xack
+        std::cout << "Group: " << group << std::endl;
+        std::cout << "Ack status: " << ack_status << std::endl;
+      });
+  }
 
-	/*sub.subscribe(group_name,
+  /*sub.subscribe(group_name,
 	              [](const cpp_redis::message_type msg) {
 			              // Callback will run for each message obtained from the queue
 			              std::cout << "Id in the cb: " << msg.get_id() << std::endl;
@@ -87,12 +87,12 @@ main() {
 			              std::cout << "Ack status: " << ack_status << std::endl;
 	              });*/
 
-	sub.commit();
+  sub.commit();
 
-	signal(SIGINT, &sigint_handler);
-	std::mutex mtx;
-	std::unique_lock<std::mutex> l(mtx);
-	should_exit.wait(l);
+  signal(SIGINT, &sigint_handler);
+  std::mutex mtx;
+  std::unique_lock<std::mutex> l(mtx);
+  should_exit.wait(l);
 
-	return 0;
+  return 0;
 }

--- a/examples/cpp_redis_future_client.cpp
+++ b/examples/cpp_redis_future_client.cpp
@@ -22,8 +22,8 @@
 
 #include <cpp_redis/cpp_redis>
 
-#include <iostream>
 #include "winsock_initializer.h"
+#include <iostream>
 
 int
 main(void) {

--- a/examples/cpp_redis_high_availability_client.cpp
+++ b/examples/cpp_redis_high_availability_client.cpp
@@ -22,8 +22,8 @@
 
 #include <cpp_redis/cpp_redis>
 
-#include <iostream>
 #include "winsock_initializer.h"
+#include <iostream>
 
 int
 main(void) {

--- a/examples/cpp_redis_kill.cpp
+++ b/examples/cpp_redis_kill.cpp
@@ -22,9 +22,9 @@
 
 #include <cpp_redis/cpp_redis>
 
+#include "winsock_initializer.h"
 #include <iostream>
 #include <sstream>
-#include "winsock_initializer.h"
 
 int
 main(void) {

--- a/examples/cpp_redis_streams_client.cpp
+++ b/examples/cpp_redis_streams_client.cpp
@@ -19,101 +19,105 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-#include <string>
-#include <cpp_redis/cpp_redis>
 #include "winsock_initializer.h"
+#include <cpp_redis/cpp_redis>
+#include <string>
 
 int
 main() {
-	winsock_initializer winsock_init;
-	//! Enable logging
-	cpp_redis::active_logger = std::unique_ptr<cpp_redis::logger>(new cpp_redis::logger);
+  winsock_initializer winsock_init;
+  //! Enable logging
+  cpp_redis::active_logger = std::unique_ptr<cpp_redis::logger>(new cpp_redis::logger);
 
-	cpp_redis::client client;
+  cpp_redis::client client;
 
-	client.connect("127.0.0.1", 6379,
-	               [](const std::string &host, std::size_t port, cpp_redis::connect_state status) {
-			               if (status == cpp_redis::connect_state::dropped) {
-				               std::cout << "client disconnected from " << host << ":" << port << std::endl;
-			               }
-	               });
+  client.connect("127.0.0.1", 6379,
+    [](const std::string& host, std::size_t port, cpp_redis::connect_state status) {
+      if (status == cpp_redis::connect_state::dropped) {
+        std::cout << "client disconnected from " << host << ":" << port << std::endl;
+      }
+    });
 
-	auto reply_cmd = [](cpp_redis::reply &reply) {
-			std::cout << "response: " << reply.as_string() << std::endl;
-	};
+  auto reply_cmd = [](cpp_redis::reply& reply) {
+    std::cout << "response: " << reply.as_string() << std::endl;
+  };
 
-	std::string message_id;
+  std::string message_id;
 
-	const std::string group_name = "groupone";
-	const std::string session_name = "sessone";
-	const std::string consumer_name = "ABCD";
+  const std::string group_name    = "groupone";
+  const std::string session_name  = "sessone";
+  const std::string consumer_name = "ABCD";
 
-	std::multimap<std::string, std::string> ins;
-	ins.insert(std::pair<std::string, std::string>{"message", "hello"});
-	ins.insert(std::pair<std::string, std::string>{"result", "a result"});
+  std::multimap<std::string, std::string> ins;
+  ins.insert(std::pair<std::string, std::string>{"message", "hello"});
+  ins.insert(std::pair<std::string, std::string>{"result", "a result"});
 
-	client.xtrim(session_name, 10, reply_cmd);
+  client.xtrim(session_name, 10, reply_cmd);
 
-	client.xgroup_create(session_name, group_name, reply_cmd);
+  client.xgroup_create(session_name, group_name, reply_cmd);
 
-	client.xadd(session_name, "*", {{"message", "hello"},
-	                                {"details", "some details"}}, [&](cpp_redis::reply &reply) {
-			std::cout << "response: " << reply.as_string() << std::endl;
-			message_id = reply.as_string();
-			std::cout << "message id: " << message_id << std::endl;
-	});
+  client.xadd(session_name, "*", {{"message", "hello"}, {"details", "some details"}}, [&](cpp_redis::reply& reply) {
+    std::cout << "response: " << reply.as_string() << std::endl;
+    message_id = reply.as_string();
+    std::cout << "message id: " << message_id << std::endl;
+  });
 
-	client.sync_commit();
+  client.sync_commit();
 
-	std::cout << "message id after: " << message_id << std::endl;
+  std::cout << "message id after: " << message_id << std::endl;
 
-	client.xack(session_name, group_name, {message_id}, reply_cmd);
-	client.xinfo_stream(session_name, [](cpp_redis::reply &reply) {
-			//std::cout << reply << std::endl;
-			cpp_redis::xinfo_reply x(reply);
-			std::cout << "Len: " << x.Length << std::endl;
-	});
-	//client.xadd(session_name, message_id, {{"final", "finished"}}, reply_cmd);
+  client.xack(session_name, group_name, {message_id}, reply_cmd);
+  client.xinfo_stream(session_name, [](cpp_redis::reply& reply) {
+    //std::cout << reply << std::endl;
+    cpp_redis::xinfo_reply x(reply);
+    std::cout << "Len: " << x.Length << std::endl;
+  });
+  //client.xadd(session_name, message_id, {{"final", "finished"}}, reply_cmd);
 
-	client.sync_commit(std::chrono::milliseconds(100));
+  client.sync_commit(std::chrono::milliseconds(100));
 
-	client.xread({Streams: {{session_name},
-	                        {message_id}},
-			             Count: 10,
-			             Block: 100}, reply_cmd);
+  client.xread({Streams : {{session_name},
+                  {message_id}},
+    Count : 10,
+    Block : 100},
+    reply_cmd);
 
-	client.sync_commit(std::chrono::milliseconds(100));
+  client.sync_commit(std::chrono::milliseconds(100));
 
-	client.xrange(session_name, {"-", "+", 10}, reply_cmd);
+  client.xrange(session_name, {"-", "+", 10}, reply_cmd);
 
-	client.xreadgroup({group_name,
-	                   "0",
-	                   {{session_name}, {">"}},
-	                   1, -1, false // count, block, no_ack
-	                  }, [](cpp_redis::reply &reply) {
-			cpp_redis::xstream_reply msg(reply);
-			std::cout << msg << std::endl;
-	});
+  client.xreadgroup({
+                      group_name,
+                      "0",
+                      {{session_name}, {">"}},
+                      1, -1, false // count, block, no_ack
+                    },
+    [](cpp_redis::reply& reply) {
+      cpp_redis::xstream_reply msg(reply);
+      std::cout << msg << std::endl;
+    });
 
-	client.sync_commit(std::chrono::milliseconds(100));
+  client.sync_commit(std::chrono::milliseconds(100));
 
-	client.xreadgroup({group_name,
-	                   consumer_name,
-	                   {{session_name}, {">"}},
-	                   1, 0, false // count, block, no_ack
-	                  }, [](cpp_redis::reply &reply) {
-			cpp_redis::xstream_reply msg(reply);
-			std::cout << msg << std::endl;
-	});
+  client.xreadgroup({
+                      group_name,
+                      consumer_name,
+                      {{session_name}, {">"}},
+                      1, 0, false // count, block, no_ack
+                    },
+    [](cpp_redis::reply& reply) {
+      cpp_redis::xstream_reply msg(reply);
+      std::cout << msg << std::endl;
+    });
 
-	// commands are pipelined and only sent when client.commit() is called
-	// client.commit();
+  // commands are pipelined and only sent when client.commit() is called
+  // client.commit();
 
-	// synchronous commit, no timeout
-	client.sync_commit(std::chrono::milliseconds(100));
+  // synchronous commit, no timeout
+  client.sync_commit(std::chrono::milliseconds(100));
 
-	// synchronous commit, timeout
-	// client.sync_commit(std::chrono::milliseconds(100));
+  // synchronous commit, timeout
+  // client.sync_commit(std::chrono::milliseconds(100));
 
-	return 0;
+  return 0;
 }

--- a/examples/cpp_redis_subscriber.cpp
+++ b/examples/cpp_redis_subscriber.cpp
@@ -23,11 +23,11 @@
 #include <cpp_redis/cpp_redis>
 #include <tacopie/tacopie>
 
+#include "winsock_initializer.h"
 #include <condition_variable>
 #include <iostream>
 #include <mutex>
 #include <signal.h>
-#include "winsock_initializer.h"
 
 std::condition_variable should_exit;
 

--- a/includes/cpp_redis/builders/array_builder.hpp
+++ b/includes/cpp_redis/builders/array_builder.hpp
@@ -29,40 +29,40 @@
 
 namespace cpp_redis {
 
-	namespace builders {
+namespace builders {
 
 /**
  * builder to build redis array replies
  *
  */
-		class array_builder : public builder_iface {
-		public:
-/**
+class array_builder : public builder_iface {
+public:
+  /**
  * ctor
  *
  */
-				array_builder();
+  array_builder();
 
-/**
+  /**
  * dtor
  *
  */
-				~array_builder() override = default;
+  ~array_builder() override = default;
 
-/**
+  /**
  * copy ctor
  *
  */
-				array_builder(const array_builder &) = delete;
+  array_builder(const array_builder&) = delete;
 
-/**
+  /**
  * assignment operator
  *
  */
-				array_builder &operator=(const array_builder &) = delete;
+  array_builder& operator=(const array_builder&) = delete;
 
-		public:
-/**
+public:
+  /**
  * take data as parameter which is consumed to build the reply
  * every bytes used to build the reply must be removed from the buffer passed as parameter
  *
@@ -70,22 +70,22 @@ namespace cpp_redis {
  * @return current instance
  *
  */
-				builder_iface &operator<<(std::string &data) override;
+  builder_iface& operator<<(std::string& data) override;
 
-/**
+  /**
  * @return whether the reply could be built
  *
  */
-				bool reply_ready() const override;
+  bool reply_ready() const override;
 
-/**
+  /**
  * @return reply object
  *
  */
-				reply get_reply() const override;
+  reply get_reply() const override;
 
-		private:
-/**
+private:
+  /**
  * take data as parameter which is consumed to determine array size
  * every bytes used to build size is removed from the buffer passed as parameter
  *
@@ -93,9 +93,9 @@ namespace cpp_redis {
  * @return true if the size could be found
  *
  */
-				bool fetch_array_size(std::string &buffer);
+  bool fetch_array_size(std::string& buffer);
 
-/**
+  /**
  * take data as parameter which is consumed to build an array row
  * every bytes used to build row is removed from the buffer passed as parameter
  *
@@ -103,41 +103,41 @@ namespace cpp_redis {
  * @return true if the row could be built
  *
  */
-				bool build_row(std::string &buffer);
+  bool build_row(std::string& buffer);
 
-		private:
-/**
+private:
+  /**
  * builder used to fetch the array size
  *
  */
-				integer_builder m_int_builder;
+  integer_builder m_int_builder;
 
-/**
+  /**
  * built array size
  *
  */
-				uint64_t m_array_size;
+  uint64_t m_array_size;
 
-/**
+  /**
  * current builder used to build current row
  *
  */
-				std::unique_ptr<builder_iface> m_current_builder;
+  std::unique_ptr<builder_iface> m_current_builder;
 
-/**
+  /**
  * whether the reply is ready or not
  *
  */
-				bool m_reply_ready;
+  bool m_reply_ready;
 
-/**
+  /**
  * reply to be built (or built)
  *
  */
-				reply m_reply;
-		};
+  reply m_reply;
+};
 
-	} // namespace builders
+} // namespace builders
 
 } // namespace cpp_redis
 

--- a/includes/cpp_redis/builders/builder_iface.hpp
+++ b/includes/cpp_redis/builders/builder_iface.hpp
@@ -30,16 +30,16 @@
 
 namespace cpp_redis {
 
-	namespace builders {
+namespace builders {
 
-		/**
+/**
 		 * @brief interface inherited by all builders
 		 */
-		class builder_iface {
-		public:
-				virtual ~builder_iface() = default;
+class builder_iface {
+public:
+  virtual ~builder_iface() = default;
 
-				/**
+  /**
 				 * take data as parameter which is consumed to build the reply
 				 * every bytes used to build the reply must be removed from the buffer passed as parameter
 				 *
@@ -47,22 +47,22 @@ namespace cpp_redis {
 				 * @return current instance
 				 *
 				 */
-				virtual builder_iface &operator<<(std::string &data) = 0;
+  virtual builder_iface& operator<<(std::string& data) = 0;
 
-				/**
+  /**
 				 * @return whether the reply could be built
 				 *
 				 */
-				virtual bool reply_ready() const = 0;
+  virtual bool reply_ready() const = 0;
 
-				/**
+  /**
 				 * @return reply object
 				 *
 				 */
-				virtual reply get_reply() const = 0;
-		};
+  virtual reply get_reply() const = 0;
+};
 
-	} // namespace builders
+} // namespace builders
 
 } // namespace cpp_redis
 

--- a/includes/cpp_redis/builders/builders_factory.hpp
+++ b/includes/cpp_redis/builders/builders_factory.hpp
@@ -28,9 +28,9 @@
 
 namespace cpp_redis {
 
-	namespace builders {
+namespace builders {
 
-		/**
+/**
 		 * create a builder corresponding to the given id
 		 *  * + for simple strings
 		 *  * - for errors
@@ -41,8 +41,8 @@ namespace cpp_redis {
 		 * @param id char that determines which builder to return
 		 * @return new builder instance depending on id value
 		 */
-		std::unique_ptr<builder_iface> create_builder(char id);
+std::unique_ptr<builder_iface> create_builder(char id);
 
-	} // namespace builders
+} // namespace builders
 
 } // namespace cpp_redis

--- a/includes/cpp_redis/builders/bulk_string_builder.hpp
+++ b/includes/cpp_redis/builders/bulk_string_builder.hpp
@@ -35,44 +35,44 @@ namespace builders {
 //!
 class bulk_string_builder : public builder_iface {
 public:
-//! ctor
+  //! ctor
   bulk_string_builder();
-//! dtor
+  //! dtor
   ~bulk_string_builder() override = default;
 
-//! copy ctor
+  //! copy ctor
   bulk_string_builder(const bulk_string_builder&) = delete;
-//! assignment operator
+  //! assignment operator
   bulk_string_builder& operator=(const bulk_string_builder&) = delete;
 
 public:
-//!
-//! take data as parameter which is consumed to build the reply
-//! every bytes used to build the reply must be removed from the buffer passed as parameter
-//!
-//! @param data data to be consumed
-//! @return current instance
-//!
+  //!
+  //! take data as parameter which is consumed to build the reply
+  //! every bytes used to build the reply must be removed from the buffer passed as parameter
+  //!
+  //! @param data data to be consumed
+  //! @return current instance
+  //!
   builder_iface& operator<<(std::string& data) override;
 
-//!
-//! @return whether the reply could be built
-//!
+  //!
+  //! @return whether the reply could be built
+  //!
   bool reply_ready() const override;
 
-//!
-//! @return reply object
-//!
+  //!
+  //! @return reply object
+  //!
   reply get_reply() const override;
 
-//!
-//! @return the parsed bulk string
-//!
+  //!
+  //! @return the parsed bulk string
+  //!
   const std::string& get_bulk_string() const;
 
-//!
-//! @return whether the bulk string is null
-//!
+  //!
+  //! @return whether the bulk string is null
+  //!
   bool is_null() const;
 
 private:
@@ -81,34 +81,34 @@ private:
   void fetch_str(std::string& str);
 
 private:
-//!
-//! builder used to get bulk string size
-//!
+  //!
+  //! builder used to get bulk string size
+  //!
   integer_builder m_int_builder;
 
-//!
-//! bulk string size
-//!
+  //!
+  //! bulk string size
+  //!
   int m_str_size;
 
-//!
-//! bulk string
-//!
+  //!
+  //! bulk string
+  //!
   std::string m_str;
 
-//!
-//! whether the bulk string is null
-//!
+  //!
+  //! whether the bulk string is null
+  //!
   bool m_is_null;
 
-//!
-//! whether the reply is ready or not
-//!
+  //!
+  //! whether the reply is ready or not
+  //!
   bool m_reply_ready;
 
-//!
-//! reply to be built
-//!
+  //!
+  //! reply to be built
+  //!
   reply m_reply;
 };
 

--- a/includes/cpp_redis/builders/error_builder.hpp
+++ b/includes/cpp_redis/builders/error_builder.hpp
@@ -36,30 +36,30 @@ namespace builders {
  */
 class error_builder : public builder_iface {
 public:
-/**
+  /**
  * ctor
  *
  */
   error_builder() = default;
-/**
+  /**
  * dtor
  *
  */
   ~error_builder() override = default;
 
-/**
+  /**
  * copy ctor
  *
  */
   error_builder(const error_builder&) = delete;
-/**
+  /**
  * assignment operator
  *
  */
   error_builder& operator=(const error_builder&) = delete;
 
 public:
-/**
+  /**
  * take data as parameter which is consumed to build the reply
  * every bytes used to build the reply must be removed from the buffer passed as parameter
  *
@@ -69,32 +69,32 @@ public:
  */
   builder_iface& operator<<(std::string& data) override;
 
-/**
+  /**
  * @return whether the reply could be built
  *
  */
   bool reply_ready() const override;
 
-/**
+  /**
  * @return reply object
  *
  */
   reply get_reply() const override;
 
-/**
+  /**
  * @return the parsed error
  *
  */
   const std::string& get_error() const;
 
 private:
-/**
+  /**
  * builder used to parse the error
  *
  */
   simple_string_builder m_string_builder;
 
-/**
+  /**
  * reply to be built
  *
  */

--- a/includes/cpp_redis/builders/integer_builder.hpp
+++ b/includes/cpp_redis/builders/integer_builder.hpp
@@ -37,30 +37,30 @@ namespace builders {
  */
 class integer_builder : public builder_iface {
 public:
-/**
+  /**
  * ctor
  *
  */
   integer_builder();
-/**
+  /**
  * dtor
  *
  */
   ~integer_builder() override = default;
 
-/**
+  /**
  * copy ctor
  *
  */
   integer_builder(const integer_builder&) = delete;
-/**
+  /**
  * assignment operator
  *
  */
   integer_builder& operator=(const integer_builder&) = delete;
 
 public:
-/**
+  /**
  * take data as parameter which is consumed to build the reply
  * every bytes used to build the reply must be removed from the buffer passed as parameter
  *
@@ -70,44 +70,44 @@ public:
  */
   builder_iface& operator<<(std::string& data) override;
 
-/**
+  /**
  * @return whether the reply could be built
  *
  */
   bool reply_ready() const override;
 
-/**
+  /**
  * @return reply object
  *
  */
   reply get_reply() const override;
 
-/**
+  /**
  * @return the parsed integer
  *
  */
   int64_t get_integer() const;
 
 private:
-/**
+  /**
  * parsed number
  *
  */
   int64_t m_nbr;
 
-/**
+  /**
  * -1 for negative number, 1 otherwise
  *
  */
   int64_t m_negative_multiplicator;
 
-/**
+  /**
  * whether the reply is ready or not
  *
  */
   bool m_reply_ready;
 
-/**
+  /**
  * reply to be built
  *
  */

--- a/includes/cpp_redis/builders/reply_builder.hpp
+++ b/includes/cpp_redis/builders/reply_builder.hpp
@@ -40,30 +40,30 @@ namespace builders {
  */
 class reply_builder {
 public:
-/**
+  /**
  * ctor
  *
  */
   reply_builder();
-/**
+  /**
  * dtor
  *
  */
   ~reply_builder() = default;
 
-/**
+  /**
  * copy ctor
  *
  */
   reply_builder(const reply_builder&) = delete;
-/**
+  /**
  * assignment operator
  *
  */
   reply_builder& operator=(const reply_builder&) = delete;
 
 public:
-/**
+  /**
  * add data to reply builder
  * data is used to build replies that can be retrieved with get_front later on if reply_available returns true
  *
@@ -73,7 +73,7 @@ public:
  */
   reply_builder& operator<<(const std::string& data);
 
-/**
+  /**
  * similar as get_front, store reply in the passed parameter
  *
  * @param reply reference to the reply object where to store the first available reply
@@ -81,32 +81,32 @@ public:
  */
   void operator>>(reply& reply);
 
-/**
+  /**
  * @return the first available reply
  *
  */
   const reply& get_front() const;
 
-/**
+  /**
  * pop the first available reply
  *
  */
   void pop_front();
 
-/**
+  /**
  * @return whether a reply is available
  *
  */
   bool reply_available() const;
 
-/**
+  /**
  * reset the reply builder to its initial state (clear internal buffer and stages)
  *
  */
   void reset();
 
 private:
-/**
+  /**
  * build reply using m_buffer content
  *
  * @return whether the reply has been fully built or not
@@ -115,19 +115,19 @@ private:
   bool build_reply();
 
 private:
-/**
+  /**
  * buffer to be used to build data
  *
  */
   std::string m_buffer;
 
-/**
+  /**
  * current builder used to build current reply
  *
  */
   std::unique_ptr<builder_iface> m_builder;
 
-/**
+  /**
  * queue of available (built) replies
  *
  */

--- a/includes/cpp_redis/builders/simple_string_builder.hpp
+++ b/includes/cpp_redis/builders/simple_string_builder.hpp
@@ -37,30 +37,30 @@ namespace builders {
  */
 class simple_string_builder : public builder_iface {
 public:
-/**
+  /**
  * ctor
  *
  */
   simple_string_builder();
-/**
+  /**
  * dtor
  *
  */
   ~simple_string_builder() override = default;
 
-/**
+  /**
  * copy ctor
  *
  */
   simple_string_builder(const simple_string_builder&) = delete;
-/**
+  /**
  * assignment operator
  *
  */
   simple_string_builder& operator=(const simple_string_builder&) = delete;
 
 public:
-/**
+  /**
  * take data as parameter which is consumed to build the reply
  * every bytes used to build the reply must be removed from the buffer passed as parameter
  *
@@ -70,38 +70,38 @@ public:
  */
   builder_iface& operator<<(std::string& data) override;
 
-/**
+  /**
  * @return whether the reply could be built
  *
  */
   bool reply_ready() const override;
 
-/**
+  /**
  * @return reply object
  *
  */
   reply get_reply() const override;
 
-/**
+  /**
  * @return the parsed simple string
  *
  */
   const std::string& get_simple_string() const;
 
 private:
-/**
+  /**
  * parsed simple string
  *
  */
   std::string m_str;
 
-/**
+  /**
  * whether the reply is ready or not
  *
  */
   bool m_reply_ready;
 
-/**
+  /**
  * reply to be built
  *
  */

--- a/includes/cpp_redis/core/client.hpp
+++ b/includes/cpp_redis/core/client.hpp
@@ -33,76 +33,75 @@
 #include <string>
 #include <vector>
 
-#include <cpp_redis/core/types.hpp>
 #include <cpp_redis/core/sentinel.hpp>
+#include <cpp_redis/core/types.hpp>
 #include <cpp_redis/helpers/variadic_template.hpp>
+#include <cpp_redis/misc/deprecated.hpp>
 #include <cpp_redis/misc/logger.hpp>
 #include <cpp_redis/network/redis_connection.hpp>
 #include <cpp_redis/network/tcp_client_iface.hpp>
-#include <cpp_redis/misc/deprecated.hpp>
 
 namespace cpp_redis {
 
-	/**
+/**
 	 * cpp_redis::client is the class providing communication with a Redis server.
 	 * It is meant to be used for sending commands to the remote server and receiving its replies.
 	 * The client support asynchronous requests, as well as synchronous ones. Moreover, commands pipelining is supported.
 	 *
 	 */
-	class client {
-	public:
-		/**
+class client {
+public:
+  /**
 		 * client type
 		 * used for client kill
 		 *
 		 */
-			enum class client_type {
-					normal,
-					master,
-					pubsub,
-					slave
-			};
+  enum class client_type {
+    normal,
+    master,
+    pubsub,
+    slave
+  };
 
-	public:
+public:
 #ifndef __CPP_REDIS_USE_CUSTOM_TCP_CLIENT
 
-			/**
+  /**
 			 * ctor
 			 *
 			 */
-			client();
+  client();
 
 #endif /* __CPP_REDIS_USE_CUSTOM_TCP_CLIENT */
 
-			/**
+  /**
 			 * custom ctor to specify custom tcp_client
 			 *
 			 * @param tcp_client tcp client to be used for network communications
 			 *
 			 */
-			explicit client(const std::shared_ptr<network::tcp_client_iface> &tcp_client);
+  explicit client(const std::shared_ptr<network::tcp_client_iface>& tcp_client);
 
-			/**
+  /**
 			 * dtor
 			 *
 			 */
-			~client();
+  ~client();
 
-			/**
+  /**
 			 * copy ctor
 			 *
 			 */
-			client(const client &) = delete;
+  client(const client&) = delete;
 
-			/**
+  /**
 			 * assignment operator
 			 *
 			 */
-			client &operator=(const client &) = delete;
+  client& operator=(const client&) = delete;
 
-	public:
-
-			/**
+public:
+  /**
 			 * Connect to redis server
 			 *
 			 * @param host host to be connected to
@@ -113,15 +112,15 @@ namespace cpp_redis {
 			 * @param reconnect_interval_ms time between two attempts of reconnection
 			 *
 			 */
-			void connect(
-					const std::string &host = "127.0.0.1",
-					std::size_t port = 6379,
-					const connect_callback_t &connect_callback = nullptr,
-					std::uint32_t timeout_ms = 0,
-					std::int32_t max_reconnects = 0,
-					std::uint32_t reconnect_interval_ms = 0);
+  void connect(
+    const std::string& host                    = "127.0.0.1",
+    std::size_t port                           = 6379,
+    const connect_callback_t& connect_callback = nullptr,
+    std::uint32_t timeout_ms                   = 0,
+    std::int32_t max_reconnects                = 0,
+    std::uint32_t reconnect_interval_ms        = 0);
 
-			/**
+  /**
 			 * Connect to redis server
 			 *
 			 * @param name sentinel name
@@ -131,48 +130,48 @@ namespace cpp_redis {
 			 * @param reconnect_interval_ms time between two attempts of reconnection
 			 *
 			 */
-			void connect(
-					const std::string &name,
-					const connect_callback_t &connect_callback = nullptr,
-					std::uint32_t timeout_ms = 0,
-					std::int32_t max_reconnects = 0,
-					std::uint32_t reconnect_interval_ms = 0);
+  void connect(
+    const std::string& name,
+    const connect_callback_t& connect_callback = nullptr,
+    std::uint32_t timeout_ms                   = 0,
+    std::int32_t max_reconnects                = 0,
+    std::uint32_t reconnect_interval_ms        = 0);
 
-			/**
+  /**
 			 * @return whether we are connected to the redis server
 			 *
 			 */
-			bool is_connected() const;
+  bool is_connected() const;
 
-			/**
+  /**
 			 * disconnect from redis server
 			 *
 			 * @param wait_for_removal when sets to true, disconnect blocks until the underlying TCP client has been effectively removed from the io_service and that all the underlying callbacks have completed.
 			 *
 			 */
-			void disconnect(bool wait_for_removal = false);
+  void disconnect(bool wait_for_removal = false);
 
-			/**
+  /**
 			 * @return whether an attempt to reconnect is in progress
 			 *
 			 */
-			bool is_reconnecting() const;
+  bool is_reconnecting() const;
 
-			/**
+  /**
 			 * stop any reconnect in progress
 			 *
 			 */
-			void cancel_reconnect();
+  void cancel_reconnect();
 
-	public:
-			/**
+public:
+  /**
 			 * reply callback called whenever a reply is received
 			 * takes as parameter the received reply
 			 *
 			 */
-			typedef std::function<void(reply &)> reply_callback_t;
+  typedef std::function<void(reply&)> reply_callback_t;
 
-			/**
+  /**
 			 * send the given command
 			 * the command is actually pipelined and only buffered, so nothing is sent to the network
 			 * please call commit() / sync_commit() to flush the buffer
@@ -182,9 +181,9 @@ namespace cpp_redis {
 			 * @return current instance
 			 *
 			 */
-			client &send(const std::vector<std::string> &redis_cmd, const reply_callback_t &callback);
+  client& send(const std::vector<std::string>& redis_cmd, const reply_callback_t& callback);
 
-			/**
+  /**
 			 * same as the other send method
 			 * but future based: does not take any callback and return an std:;future to handle the reply
 			 *
@@ -192,9 +191,9 @@ namespace cpp_redis {
 			 * @return std::future to handler redis reply
 			 *
 			 */
-			std::future<reply> send(const std::vector<std::string> &redis_cmd);
+  std::future<reply> send(const std::vector<std::string>& redis_cmd);
 
-			/**
+  /**
 			 * Sends all the commands that have been stored by calling send() since the last commit() call to the redis server.
 			 * That is, pipelining is supported in a very simple and efficient way: client.send(...).send(...).send(...).commit() will send the 3 commands at once (instead of sending 3 network requests, one for each command, as it would have been done without pipelining).
 			 * Pipelined commands are always removed from the buffer, even in the case of an error (for example, calling commit while the client is not connected, something that throws an exception).
@@ -203,88 +202,89 @@ namespace cpp_redis {
 			 * Please note that, while commit() can safely be called from inside a reply callback, calling sync_commit() from inside a reply callback is not permitted and will lead to undefined behavior, mostly deadlock.
 			 *
 			 */
-			client &commit();
+  client& commit();
 
-			/**
+  /**
 			 * same as commit(), but synchronous
 			 * will block until all pending commands have been sent and that a reply has been received for each of them and all underlying callbacks completed
 			 *
 			 * @return current instance
 			 *
 			 */
-			client &sync_commit();
+  client& sync_commit();
 
-			/**
+  /**
 			 * same as sync_commit, but with a timeout
 			 * will simply block until it completes or timeout expires
 			 *
 			 * @return current instance
 			 *
 			 */
-			template<class Rep, class Period>
-			client &
-			sync_commit(const std::chrono::duration<Rep, Period> &timeout) {
-				/**
+  template <class Rep, class Period>
+  client&
+  sync_commit(const std::chrono::duration<Rep, Period>& timeout) {
+    /**
 				 * no need to call commit in case of reconnection
 				 * the reconnection flow will do it for us
 				 *
 				 */
-				if (!is_reconnecting()) {
-					try_commit();
-				}
+    if (!is_reconnecting()) {
+      try_commit();
+    }
 
-				std::unique_lock<std::mutex> lock_callback(m_callbacks_mutex);
-				__CPP_REDIS_LOG(debug, "cpp_redis::client waiting for callbacks to complete");
-				if (!m_sync_condvar.wait_for(lock_callback, timeout,
-				                             [=] { return m_callbacks_running == 0 && m_commands.empty(); })) {
-					__CPP_REDIS_LOG(debug, "cpp_redis::client finished waiting for callback");
-				} else {
-					__CPP_REDIS_LOG(debug, "cpp_redis::client timed out waiting for callback");
-				}
+    std::unique_lock<std::mutex> lock_callback(m_callbacks_mutex);
+    __CPP_REDIS_LOG(debug, "cpp_redis::client waiting for callbacks to complete");
+    if (!m_sync_condvar.wait_for(lock_callback, timeout,
+          [=] { return m_callbacks_running == 0 && m_commands.empty(); })) {
+      __CPP_REDIS_LOG(debug, "cpp_redis::client finished waiting for callback");
+    }
+    else {
+      __CPP_REDIS_LOG(debug, "cpp_redis::client timed out waiting for callback");
+    }
 
-				return *this;
-			}
+    return *this;
+  }
 
-	private:
-			/**
+private:
+  /**
 			 * @return whether a reconnection attempt should be performed
 			 *
 			 */
-			bool should_reconnect() const;
+  bool should_reconnect() const;
 
-			/**
+  /**
 			 * resend all pending commands that failed to be sent due to disconnection
 			 *
 			 */
-			void resend_failed_commands();
+  void resend_failed_commands();
 
-			/**
+  /**
 			 * sleep between two reconnect attempts if necessary
 			 *
 			 */
-			void sleep_before_next_reconnect_attempt();
+  void sleep_before_next_reconnect_attempt();
 
-/**
+  /**
  * reconnect to the previously connected host
  * automatically re authenticate and resubscribe to subscribed channel in case of success
  *
  */
-			void reconnect();
+  void reconnect();
 
-/**
+  /**
  * re authenticate to redis server based on previously used password
  *
  */
-			void re_auth();
+  void re_auth();
 
-/**
+  /**
  * re select db to redis server based on previously selected db
  *
  */
-			void re_select();
+  void re_select();
 
-	private:
-/**
+private:
+  /**
  * unprotected send
  * same as send, but without any mutex lock
  *
@@ -292,9 +292,9 @@ namespace cpp_redis {
  * @param callback callback to be called whenever a reply is received
  *
  */
-			void unprotected_send(const std::vector<std::string> &redis_cmd, const reply_callback_t &callback);
+  void unprotected_send(const std::vector<std::string>& redis_cmd, const reply_callback_t& callback);
 
-/**
+  /**
  * unprotected auth
  * same as auth, but without any mutex lock
  *
@@ -302,9 +302,9 @@ namespace cpp_redis {
  * @param reply_callback callback to be called whenever a reply is received
  *
  */
-			void unprotected_auth(const std::string &password, const reply_callback_t &reply_callback);
+  void unprotected_auth(const std::string& password, const reply_callback_t& reply_callback);
 
-/**
+  /**
  * unprotected select
  * same as select, but without any mutex lock
  *
@@ -312,10 +312,10 @@ namespace cpp_redis {
  * @param reply_callback callback to be called whenever a reply is received
  *
  */
-			void unprotected_select(int index, const reply_callback_t &reply_callback);
+  void unprotected_select(int index, const reply_callback_t& reply_callback);
 
-	public:
-/**
+public:
+  /**
  * add a sentinel definition. Required for connect() or get_master_addr_by_name() when autoconnect is enabled.
  *
  * @param host sentinel host
@@ -323,158 +323,158 @@ namespace cpp_redis {
  * @param timeout_ms maximum time to connect
  *
  */
-			void add_sentinel(const std::string &host, std::size_t port, std::uint32_t timeout_ms = 0);
+  void add_sentinel(const std::string& host, std::size_t port, std::uint32_t timeout_ms = 0);
 
-/**
+  /**
  * retrieve sentinel for current client
  *
  * @return sentinel associated to current client
  *
  */
-			const sentinel &get_sentinel() const;
+  const sentinel& get_sentinel() const;
 
-/**
+  /**
  * retrieve sentinel for current client
  * non-const version
  *
  * @return sentinel associated to current client
  *
  */
-			sentinel &get_sentinel();
+  sentinel& get_sentinel();
 
-/**
+  /**
  * clear all existing sentinels.
  *
  */
-			void clear_sentinels();
+  void clear_sentinels();
 
-	public:
-/**
+public:
+  /**
  * aggregate method to be used for some commands (like zunionstore)
  * these match the aggregate methods supported by redis
  * use server_default if you are not willing to specify this parameter and let the server defaults
  *
  */
-			enum class aggregate_method {
-					sum,
-					min,
-					max,
-					server_default
-			};
+  enum class aggregate_method {
+    sum,
+    min,
+    max,
+    server_default
+  };
 
-/**
+  /**
  * convert an aggregate_method enum to its equivalent redis-server string
  *
  * @param method aggregate_method to convert
  * @return conversion
  *
  */
-			std::string aggregate_method_to_string(aggregate_method method) const;
+  std::string aggregate_method_to_string(aggregate_method method) const;
 
-	public:
-/**
+public:
+  /**
  * geographic unit to be used for some commands (like georadius)
  * these match the geo units supported by redis-server
  *
  */
-			enum class geo_unit {
-					m,
-					km,
-					ft,
-					mi
-			};
+  enum class geo_unit {
+    m,
+    km,
+    ft,
+    mi
+  };
 
-/**
+  /**
  * convert a geo unit to its equivalent redis-server string
  *
  * @param unit geo_unit to convert
  * @return conversion
  *
  */
-			std::string geo_unit_to_string(geo_unit unit) const;
+  std::string geo_unit_to_string(geo_unit unit) const;
 
-	public:
-/**
+public:
+  /**
  * overflow type to be used for some commands (like bitfield)
  * these match the overflow types supported by redis-server
  * use server_default if you are not willing to specify this parameter and let the server defaults
  *
  */
-			enum class overflow_type {
-					wrap,
-					sat,
-					fail,
-					server_default
-			};
+  enum class overflow_type {
+    wrap,
+    sat,
+    fail,
+    server_default
+  };
 
-/**
+  /**
  * convert an overflow type to its equivalent redis-server string
  *
  * @param type overflow type to convert
  * @return conversion
  *
  */
-			std::string overflow_type_to_string(overflow_type type) const;
+  std::string overflow_type_to_string(overflow_type type) const;
 
-	public:
-/**
+public:
+  /**
  * bitfield operation type to be used for some commands (like bitfield)
  * these match the bitfield operation types supported by redis-server
  *
  */
-			enum class bitfield_operation_type {
-					get,
-					set,
-					incrby
-			};
+  enum class bitfield_operation_type {
+    get,
+    set,
+    incrby
+  };
 
-/**
+  /**
  * convert a bitfield operation type to its equivalent redis-server string
  *
  * @param operation operation type to convert
  * @return conversion
  *
  */
-			std::string
-			bitfield_operation_type_to_string(bitfield_operation_type operation) const;
+  std::string
+  bitfield_operation_type_to_string(bitfield_operation_type operation) const;
 
-	public:
-/**
+public:
+  /**
  * used to store a get, set or incrby bitfield operation (for bitfield command)
  *
  */
-			struct bitfield_operation {
-/**
+  struct bitfield_operation {
+    /**
  * operation type (get, set, incrby)
  *
  */
-					bitfield_operation_type operation_type;
+    bitfield_operation_type operation_type;
 
-/**
+    /**
  * redis type parameter for get, set or incrby operations
  *
  */
-					std::string type;
+    std::string type;
 
-/**
+    /**
  * redis offset parameter for get, set or incrby operations
  *
  */
-					int offset;
+    int offset;
 
-/**
+    /**
  * redis value parameter for set operation, or increment parameter for incrby operation
  *
  */
-					int value;
+    int value;
 
-/**
+    /**
  * overflow optional specification
  *
  */
-					overflow_type overflow;
+    overflow_type overflow;
 
-/**
+    /**
  * build a bitfield_operation for a bitfield get operation
  *
  * @param type type param of a get operation
@@ -483,10 +483,10 @@ namespace cpp_redis {
  * @return corresponding get bitfield_operation
  *
  */
-					static bitfield_operation
-					get(const std::string &type, int offset, overflow_type overflow = overflow_type::server_default);
+    static bitfield_operation
+    get(const std::string& type, int offset, overflow_type overflow = overflow_type::server_default);
 
-/**
+    /**
  * build a bitfield_operation for a bitfield set operation
  *
  * @param type type param of a set operation
@@ -496,10 +496,10 @@ namespace cpp_redis {
  * @return corresponding set bitfield_operation
  *
  */
-					static bitfield_operation
-					set(const std::string &type, int offset, int value, overflow_type overflow = overflow_type::server_default);
+    static bitfield_operation
+    set(const std::string& type, int offset, int value, overflow_type overflow = overflow_type::server_default);
 
-/**
+    /**
  * build a bitfield_operation for a bitfield incrby operation
  *
  * @param type type param of a incrby operation
@@ -509,1019 +509,1019 @@ namespace cpp_redis {
  * @return corresponding incrby bitfield_operation
  *
  */
-					static bitfield_operation incrby(const std::string &type, int offset, int increment,
-					                                 overflow_type overflow = overflow_type::server_default);
-			};
+    static bitfield_operation incrby(const std::string& type, int offset, int increment,
+      overflow_type overflow = overflow_type::server_default);
+  };
 
-	public:
-			client &
-			append(const std::string &key, const std::string &value, const reply_callback_t &reply_callback);
+public:
+  client&
+  append(const std::string& key, const std::string& value, const reply_callback_t& reply_callback);
 
-			std::future<reply> append(const std::string &key, const std::string &value);
+  std::future<reply> append(const std::string& key, const std::string& value);
 
-			client &auth(const std::string &password, const reply_callback_t &reply_callback);
+  client& auth(const std::string& password, const reply_callback_t& reply_callback);
 
-			std::future<reply> auth(const std::string &password);
+  std::future<reply> auth(const std::string& password);
 
-			client &bgrewriteaof(const reply_callback_t &reply_callback);
+  client& bgrewriteaof(const reply_callback_t& reply_callback);
 
-			std::future<reply> bgrewriteaof();
+  std::future<reply> bgrewriteaof();
 
-			client &bgsave(const reply_callback_t &reply_callback);
+  client& bgsave(const reply_callback_t& reply_callback);
 
-			std::future<reply> bgsave();
+  std::future<reply> bgsave();
 
-			client &bitcount(const std::string &key, const reply_callback_t &reply_callback);
+  client& bitcount(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> bitcount(const std::string &key);
+  std::future<reply> bitcount(const std::string& key);
 
-			client &bitcount(const std::string &key, int start, int end, const reply_callback_t &reply_callback);
+  client& bitcount(const std::string& key, int start, int end, const reply_callback_t& reply_callback);
 
-			std::future<reply> bitcount(const std::string &key, int start, int end);
+  std::future<reply> bitcount(const std::string& key, int start, int end);
 
-			client &bitfield(const std::string &key, const std::vector<bitfield_operation> &operations,
-			                 const reply_callback_t &reply_callback);
+  client& bitfield(const std::string& key, const std::vector<bitfield_operation>& operations,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> bitfield(const std::string &key, const std::vector<bitfield_operation> &operations);
+  std::future<reply> bitfield(const std::string& key, const std::vector<bitfield_operation>& operations);
 
-			client &bitop(const std::string &operation, const std::string &destkey, const std::vector<std::string> &keys,
-			              const reply_callback_t &reply_callback);
+  client& bitop(const std::string& operation, const std::string& destkey, const std::vector<std::string>& keys,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			bitop(const std::string &operation, const std::string &destkey, const std::vector<std::string> &keys);
+  std::future<reply>
+  bitop(const std::string& operation, const std::string& destkey, const std::vector<std::string>& keys);
 
-			client &bitpos(const std::string &key, int bit, const reply_callback_t &reply_callback);
+  client& bitpos(const std::string& key, int bit, const reply_callback_t& reply_callback);
 
-			std::future<reply> bitpos(const std::string &key, int bit);
+  std::future<reply> bitpos(const std::string& key, int bit);
 
-			client &bitpos(const std::string &key, int bit, int start, const reply_callback_t &reply_callback);
+  client& bitpos(const std::string& key, int bit, int start, const reply_callback_t& reply_callback);
 
-			std::future<reply> bitpos(const std::string &key, int bit, int start);
+  std::future<reply> bitpos(const std::string& key, int bit, int start);
 
-			client &bitpos(const std::string &key, int bit, int start, int end, const reply_callback_t &reply_callback);
+  client& bitpos(const std::string& key, int bit, int start, int end, const reply_callback_t& reply_callback);
 
-			std::future<reply> bitpos(const std::string &key, int bit, int start, int end);
+  std::future<reply> bitpos(const std::string& key, int bit, int start, int end);
 
-			client &blpop(const std::vector<std::string> &keys, int timeout, const reply_callback_t &reply_callback);
+  client& blpop(const std::vector<std::string>& keys, int timeout, const reply_callback_t& reply_callback);
 
-			std::future<reply> blpop(const std::vector<std::string> &keys, int timeout);
+  std::future<reply> blpop(const std::vector<std::string>& keys, int timeout);
 
-			client &brpop(const std::vector<std::string> &keys, int timeout, const reply_callback_t &reply_callback);
+  client& brpop(const std::vector<std::string>& keys, int timeout, const reply_callback_t& reply_callback);
 
-			std::future<reply> brpop(const std::vector<std::string> &keys, int timeout);
+  std::future<reply> brpop(const std::vector<std::string>& keys, int timeout);
 
-			client &
-			brpoplpush(const std::string &src, const std::string &dst, int timeout, const reply_callback_t &reply_callback);
+  client&
+  brpoplpush(const std::string& src, const std::string& dst, int timeout, const reply_callback_t& reply_callback);
 
-			std::future<reply> brpoplpush(const std::string &src, const std::string &dst, int timeout);
+  std::future<reply> brpoplpush(const std::string& src, const std::string& dst, int timeout);
 
-			client& bzpopmin(const std::vector<std::string>& keys, int timeout, const reply_callback_t& reply_callback);
+  client& bzpopmin(const std::vector<std::string>& keys, int timeout, const reply_callback_t& reply_callback);
 
-			std::future<reply> bzpopmin(const std::vector<std::string>& keys, int timeout);
+  std::future<reply> bzpopmin(const std::vector<std::string>& keys, int timeout);
 
-			client& bzpopmax(const std::vector<std::string>& keys, int timeout, const reply_callback_t& reply_callback);
+  client& bzpopmax(const std::vector<std::string>& keys, int timeout, const reply_callback_t& reply_callback);
 
-			std::future<reply> bzpopmax(const std::vector<std::string>& keys, int timeout);
+  std::future<reply> bzpopmax(const std::vector<std::string>& keys, int timeout);
 
-			client& client_id(const reply_callback_t& reply_callback);
+  client& client_id(const reply_callback_t& reply_callback);
 
-			std::future<reply> client_id();
+  std::future<reply> client_id();
 
-			//<editor-fold desc="client">
-			template<typename T, typename... Ts>
-			client &client_kill(const std::string &host, int port, const T &arg, const Ts &... args);
+  //<editor-fold desc="client">
+  template <typename T, typename... Ts>
+  client& client_kill(const std::string& host, int port, const T& arg, const Ts&... args);
 
-			client &client_kill(const std::string &host, int port);
+  client& client_kill(const std::string& host, int port);
 
-			template<typename... Ts>
-			client &client_kill(const char *host, int port, const Ts &... args);
+  template <typename... Ts>
+  client& client_kill(const char* host, int port, const Ts&... args);
 
-			template<typename T, typename... Ts>
-			client &client_kill(const T &, const Ts &...);
+  template <typename T, typename... Ts>
+  client& client_kill(const T&, const Ts&...);
 
-			template<typename T, typename... Ts>
-			std::future<reply> client_kill_future(T, const Ts...);
+  template <typename T, typename... Ts>
+  std::future<reply> client_kill_future(T, const Ts...);
 
-			client &client_list(const reply_callback_t &reply_callback);
+  client& client_list(const reply_callback_t& reply_callback);
 
-			std::future<reply> client_list();
+  std::future<reply> client_list();
 
-			client &client_getname(const reply_callback_t &reply_callback);
+  client& client_getname(const reply_callback_t& reply_callback);
 
-			std::future<reply> client_getname();
+  std::future<reply> client_getname();
 
-			client &client_pause(int timeout, const reply_callback_t &reply_callback);
+  client& client_pause(int timeout, const reply_callback_t& reply_callback);
 
-			std::future<reply> client_pause(int timeout);
+  std::future<reply> client_pause(int timeout);
 
-			client &client_reply(const std::string &mode, const reply_callback_t &reply_callback);
+  client& client_reply(const std::string& mode, const reply_callback_t& reply_callback);
 
-			std::future<reply> client_reply(const std::string &mode);
+  std::future<reply> client_reply(const std::string& mode);
 
-			client &client_setname(const std::string &name, const reply_callback_t &reply_callback);
+  client& client_setname(const std::string& name, const reply_callback_t& reply_callback);
 
-			std::future<reply> client_setname(const std::string &name);
-			//</editor-fold>
+  std::future<reply> client_setname(const std::string& name);
+  //</editor-fold>
 
-			client& client_unblock(int id, const reply_callback_t& reply_callback);
+  client& client_unblock(int id, const reply_callback_t& reply_callback);
 
-			client& client_unblock(int id, bool witherror, const reply_callback_t& reply_callback);
+  client& client_unblock(int id, bool witherror, const reply_callback_t& reply_callback);
 
-			std::future<reply> client_unblock(int id, bool witherror = false);
+  std::future<reply> client_unblock(int id, bool witherror = false);
 
-			client &cluster_addslots(const std::vector<std::string> &p_slots, const reply_callback_t &reply_callback);
+  client& cluster_addslots(const std::vector<std::string>& p_slots, const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_addslots(const std::vector<std::string> &p_slots);
+  std::future<reply> cluster_addslots(const std::vector<std::string>& p_slots);
 
-			client &cluster_count_failure_reports(const std::string &node_id, const reply_callback_t &reply_callback);
+  client& cluster_count_failure_reports(const std::string& node_id, const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_count_failure_reports(const std::string &node_id);
+  std::future<reply> cluster_count_failure_reports(const std::string& node_id);
 
-			client &cluster_countkeysinslot(const std::string &slot, const reply_callback_t &reply_callback);
+  client& cluster_countkeysinslot(const std::string& slot, const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_countkeysinslot(const std::string &slot);
+  std::future<reply> cluster_countkeysinslot(const std::string& slot);
 
-			client &cluster_delslots(const std::vector<std::string> &p_slots, const reply_callback_t &reply_callback);
+  client& cluster_delslots(const std::vector<std::string>& p_slots, const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_delslots(const std::vector<std::string> &p_slots);
+  std::future<reply> cluster_delslots(const std::vector<std::string>& p_slots);
 
-			client &cluster_failover(const reply_callback_t &reply_callback);
+  client& cluster_failover(const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_failover();
+  std::future<reply> cluster_failover();
 
-			client &cluster_failover(const std::string &mode, const reply_callback_t &reply_callback);
+  client& cluster_failover(const std::string& mode, const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_failover(const std::string &mode);
+  std::future<reply> cluster_failover(const std::string& mode);
 
-			client &cluster_forget(const std::string &node_id, const reply_callback_t &reply_callback);
+  client& cluster_forget(const std::string& node_id, const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_forget(const std::string &node_id);
+  std::future<reply> cluster_forget(const std::string& node_id);
 
-			client &cluster_getkeysinslot(const std::string &slot, int count, const reply_callback_t &reply_callback);
+  client& cluster_getkeysinslot(const std::string& slot, int count, const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_getkeysinslot(const std::string &slot, int count);
+  std::future<reply> cluster_getkeysinslot(const std::string& slot, int count);
 
-			client &cluster_info(const reply_callback_t &reply_callback);
+  client& cluster_info(const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_info();
+  std::future<reply> cluster_info();
 
-			client &cluster_keyslot(const std::string &key, const reply_callback_t &reply_callback);
+  client& cluster_keyslot(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_keyslot(const std::string &key);
+  std::future<reply> cluster_keyslot(const std::string& key);
 
-			client &cluster_meet(const std::string &ip, int port, const reply_callback_t &reply_callback);
+  client& cluster_meet(const std::string& ip, int port, const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_meet(const std::string &ip, int port);
+  std::future<reply> cluster_meet(const std::string& ip, int port);
 
-			client &cluster_nodes(const reply_callback_t &reply_callback);
+  client& cluster_nodes(const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_nodes();
+  std::future<reply> cluster_nodes();
 
-			client &cluster_replicate(const std::string &node_id, const reply_callback_t &reply_callback);
+  client& cluster_replicate(const std::string& node_id, const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_replicate(const std::string &node_id);
+  std::future<reply> cluster_replicate(const std::string& node_id);
 
-			client &cluster_reset(const reply_callback_t &reply_callback);
+  client& cluster_reset(const reply_callback_t& reply_callback);
 
-			client &cluster_reset(const std::string &mode, const reply_callback_t &reply_callback);
+  client& cluster_reset(const std::string& mode, const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_reset(const std::string &mode = "soft");
+  std::future<reply> cluster_reset(const std::string& mode = "soft");
 
-			client &cluster_saveconfig(const reply_callback_t &reply_callback);
+  client& cluster_saveconfig(const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_saveconfig();
+  std::future<reply> cluster_saveconfig();
 
-			client &cluster_set_config_epoch(const std::string &epoch, const reply_callback_t &reply_callback);
+  client& cluster_set_config_epoch(const std::string& epoch, const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_set_config_epoch(const std::string &epoch);
+  std::future<reply> cluster_set_config_epoch(const std::string& epoch);
 
-			client &cluster_setslot(const std::string &slot, const std::string &mode, const reply_callback_t &reply_callback);
+  client& cluster_setslot(const std::string& slot, const std::string& mode, const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_setslot(const std::string &slot, const std::string &mode);
+  std::future<reply> cluster_setslot(const std::string& slot, const std::string& mode);
 
-			client &cluster_setslot(const std::string &slot, const std::string &mode, const std::string &node_id,
-			                        const reply_callback_t &reply_callback);
+  client& cluster_setslot(const std::string& slot, const std::string& mode, const std::string& node_id,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_setslot(const std::string &slot, const std::string &mode, const std::string &node_id);
+  std::future<reply> cluster_setslot(const std::string& slot, const std::string& mode, const std::string& node_id);
 
-			client &cluster_slaves(const std::string &node_id, const reply_callback_t &reply_callback);
+  client& cluster_slaves(const std::string& node_id, const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_slaves(const std::string &node_id);
+  std::future<reply> cluster_slaves(const std::string& node_id);
 
-			client &cluster_slots(const reply_callback_t &reply_callback);
+  client& cluster_slots(const reply_callback_t& reply_callback);
 
-			std::future<reply> cluster_slots();
+  std::future<reply> cluster_slots();
 
-			client &command(const reply_callback_t &reply_callback);
+  client& command(const reply_callback_t& reply_callback);
 
-			std::future<reply> command();
+  std::future<reply> command();
 
-			client &command_count(const reply_callback_t &reply_callback);
+  client& command_count(const reply_callback_t& reply_callback);
 
-			std::future<reply> command_count();
+  std::future<reply> command_count();
 
-			client &command_getkeys(const reply_callback_t &reply_callback);
+  client& command_getkeys(const reply_callback_t& reply_callback);
 
-			std::future<reply> command_getkeys();
+  std::future<reply> command_getkeys();
 
-			client &command_info(const std::vector<std::string> &command_name, const reply_callback_t &reply_callback);
+  client& command_info(const std::vector<std::string>& command_name, const reply_callback_t& reply_callback);
 
-			std::future<reply> command_info(const std::vector<std::string> &command_name);
+  std::future<reply> command_info(const std::vector<std::string>& command_name);
 
-			client &config_get(const std::string &param, const reply_callback_t &reply_callback);
+  client& config_get(const std::string& param, const reply_callback_t& reply_callback);
 
-			std::future<reply> config_get(const std::string &param);
+  std::future<reply> config_get(const std::string& param);
 
-			client &config_rewrite(const reply_callback_t &reply_callback);
+  client& config_rewrite(const reply_callback_t& reply_callback);
 
-			std::future<reply> config_rewrite();
+  std::future<reply> config_rewrite();
 
-			client &config_set(const std::string &param, const std::string &val, const reply_callback_t &reply_callback);
+  client& config_set(const std::string& param, const std::string& val, const reply_callback_t& reply_callback);
 
-			std::future<reply> config_set(const std::string &param, const std::string &val);
+  std::future<reply> config_set(const std::string& param, const std::string& val);
 
-			client &config_resetstat(const reply_callback_t &reply_callback);
+  client& config_resetstat(const reply_callback_t& reply_callback);
 
-			std::future<reply> config_resetstat();
+  std::future<reply> config_resetstat();
 
-			client &dbsize(const reply_callback_t &reply_callback);
+  client& dbsize(const reply_callback_t& reply_callback);
 
-			std::future<reply> dbsize();
+  std::future<reply> dbsize();
 
-			client &debug_object(const std::string &key, const reply_callback_t &reply_callback);
+  client& debug_object(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> debug_object(const std::string &key);
+  std::future<reply> debug_object(const std::string& key);
 
-			client &debug_segfault(const reply_callback_t &reply_callback);
+  client& debug_segfault(const reply_callback_t& reply_callback);
 
-			std::future<reply> debug_segfault();
+  std::future<reply> debug_segfault();
 
-			client &decr(const std::string &key, const reply_callback_t &reply_callback);
+  client& decr(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> decr(const std::string &key);
+  std::future<reply> decr(const std::string& key);
 
-			client &decrby(const std::string &key, int val, const reply_callback_t &reply_callback);
+  client& decrby(const std::string& key, int val, const reply_callback_t& reply_callback);
 
-			std::future<reply> decrby(const std::string &key, int val);
+  std::future<reply> decrby(const std::string& key, int val);
 
-			client &del(const std::vector<std::string> &key, const reply_callback_t &reply_callback);
+  client& del(const std::vector<std::string>& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> del(const std::vector<std::string> &key);
+  std::future<reply> del(const std::vector<std::string>& key);
 
-			client &discard(const reply_callback_t &reply_callback);
+  client& discard(const reply_callback_t& reply_callback);
 
-			std::future<reply> discard();
+  std::future<reply> discard();
 
-			client &dump(const std::string &key, const reply_callback_t &reply_callback);
+  client& dump(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> dump(const std::string &key);
+  std::future<reply> dump(const std::string& key);
 
-			client &echo(const std::string &msg, const reply_callback_t &reply_callback);
+  client& echo(const std::string& msg, const reply_callback_t& reply_callback);
 
-			std::future<reply> echo(const std::string &msg);
+  std::future<reply> echo(const std::string& msg);
 
-			client &eval(const std::string &script, const std::vector<std::string> &keys,
-			             const std::vector<std::string> &args, const reply_callback_t &reply_callback);
+  client& eval(const std::string& script, const std::vector<std::string>& keys,
+    const std::vector<std::string>& args, const reply_callback_t& reply_callback);
 
-			DEPRECATED client &eval(const std::string &script, int numkeys, const std::vector<std::string> &keys,
-			             const std::vector<std::string> &args, const reply_callback_t &reply_callback);
+  DEPRECATED client& eval(const std::string& script, int numkeys, const std::vector<std::string>& keys,
+    const std::vector<std::string>& args, const reply_callback_t& reply_callback);
 
-			std::future<reply> eval(const std::string &script, const std::vector<std::string> &keys,
-			                        const std::vector<std::string> &args);
+  std::future<reply> eval(const std::string& script, const std::vector<std::string>& keys,
+    const std::vector<std::string>& args);
 
-			DEPRECATED std::future<reply> eval(const std::string &script, int numkeys, const std::vector<std::string> &keys,
-			                        const std::vector<std::string> &args);
+  DEPRECATED std::future<reply> eval(const std::string& script, int numkeys, const std::vector<std::string>& keys,
+    const std::vector<std::string>& args);
 
-			client &evalsha(const std::string &sha1, const std::vector<std::string> &keys,
-			                const std::vector<std::string> &args, const reply_callback_t &reply_callback);
+  client& evalsha(const std::string& sha1, const std::vector<std::string>& keys,
+    const std::vector<std::string>& args, const reply_callback_t& reply_callback);
 
-			DEPRECATED client &evalsha(const std::string &sha1, int numkeys, const std::vector<std::string> &keys,
-			                const std::vector<std::string> &args, const reply_callback_t &reply_callback);
+  DEPRECATED client& evalsha(const std::string& sha1, int numkeys, const std::vector<std::string>& keys,
+    const std::vector<std::string>& args, const reply_callback_t& reply_callback);
 
-			std::future<reply> evalsha(const std::string &sha1, const std::vector<std::string> &keys,
-			                           const std::vector<std::string> &args);
+  std::future<reply> evalsha(const std::string& sha1, const std::vector<std::string>& keys,
+    const std::vector<std::string>& args);
 
-			DEPRECATED std::future<reply> evalsha(const std::string &sha1, int numkeys, const std::vector<std::string> &keys,
-			                           const std::vector<std::string> &args);
+  DEPRECATED std::future<reply> evalsha(const std::string& sha1, int numkeys, const std::vector<std::string>& keys,
+    const std::vector<std::string>& args);
 
-			client &exec(const reply_callback_t &reply_callback);
+  client& exec(const reply_callback_t& reply_callback);
 
-			std::future<reply> exec();
+  std::future<reply> exec();
 
-			client &exists(const std::vector<std::string> &keys, const reply_callback_t &reply_callback);
+  client& exists(const std::vector<std::string>& keys, const reply_callback_t& reply_callback);
 
-			std::future<reply> exists(const std::vector<std::string> &keys);
+  std::future<reply> exists(const std::vector<std::string>& keys);
 
-			client &expire(const std::string &key, int seconds, const reply_callback_t &reply_callback);
+  client& expire(const std::string& key, int seconds, const reply_callback_t& reply_callback);
 
-			std::future<reply> expire(const std::string &key, int seconds);
+  std::future<reply> expire(const std::string& key, int seconds);
 
-			client &expireat(const std::string &key, int timestamp, const reply_callback_t &reply_callback);
+  client& expireat(const std::string& key, int timestamp, const reply_callback_t& reply_callback);
 
-			std::future<reply> expireat(const std::string &key, int timestamp);
+  std::future<reply> expireat(const std::string& key, int timestamp);
 
-			client &flushall(const reply_callback_t &reply_callback);
+  client& flushall(const reply_callback_t& reply_callback);
 
-			std::future<reply> flushall();
+  std::future<reply> flushall();
 
-			client &flushdb(const reply_callback_t &reply_callback);
+  client& flushdb(const reply_callback_t& reply_callback);
 
-			std::future<reply> flushdb();
+  std::future<reply> flushdb();
 
-			client &geoadd(const std::string &key,
-			               const std::vector<std::tuple<std::string, std::string, std::string>> &long_lat_memb,
-			               const reply_callback_t &reply_callback);
+  client& geoadd(const std::string& key,
+    const std::vector<std::tuple<std::string, std::string, std::string>>& long_lat_memb,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> geoadd(const std::string &key,
-			                          const std::vector<std::tuple<std::string, std::string, std::string>> &long_lat_memb);
+  std::future<reply> geoadd(const std::string& key,
+    const std::vector<std::tuple<std::string, std::string, std::string>>& long_lat_memb);
 
-			client &
-			geohash(const std::string &key, const std::vector<std::string> &members, const reply_callback_t &reply_callback);
+  client&
+  geohash(const std::string& key, const std::vector<std::string>& members, const reply_callback_t& reply_callback);
 
-			std::future<reply> geohash(const std::string &key, const std::vector<std::string> &members);
+  std::future<reply> geohash(const std::string& key, const std::vector<std::string>& members);
 
-			client &
-			geopos(const std::string &key, const std::vector<std::string> &members, const reply_callback_t &reply_callback);
+  client&
+  geopos(const std::string& key, const std::vector<std::string>& members, const reply_callback_t& reply_callback);
 
-			std::future<reply> geopos(const std::string &key, const std::vector<std::string> &members);
+  std::future<reply> geopos(const std::string& key, const std::vector<std::string>& members);
 
-			client &geodist(const std::string &key, const std::string &member_1, const std::string &member_2,
-			                const reply_callback_t &reply_callback);
+  client& geodist(const std::string& key, const std::string& member_1, const std::string& member_2,
+    const reply_callback_t& reply_callback);
 
-			client &
-			geodist(const std::string &key, const std::string &member_1, const std::string &member_2, const std::string &unit,
-			        const reply_callback_t &reply_callback);
+  client&
+  geodist(const std::string& key, const std::string& member_1, const std::string& member_2, const std::string& unit,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> geodist(const std::string &key, const std::string &member_1, const std::string &member_2,
-			                           const std::string &unit = "m");
+  std::future<reply> geodist(const std::string& key, const std::string& member_1, const std::string& member_2,
+    const std::string& unit = "m");
 
-			client &georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
-			                  bool with_coord, bool with_dist, bool with_hash, bool asc_order,
-			                  const reply_callback_t &reply_callback);
+  client& georadius(const std::string& key, double longitude, double latitude, double radius, geo_unit unit,
+    bool with_coord, bool with_dist, bool with_hash, bool asc_order,
+    const reply_callback_t& reply_callback);
 
-			client &georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
-			                  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
-			                  const reply_callback_t &reply_callback);
+  client& georadius(const std::string& key, double longitude, double latitude, double radius, geo_unit unit,
+    bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
+    const reply_callback_t& reply_callback);
 
-			client &georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
-			                  bool with_coord, bool with_dist, bool with_hash, bool asc_order, const std::string &store_key,
-			                  const reply_callback_t &reply_callback);
+  client& georadius(const std::string& key, double longitude, double latitude, double radius, geo_unit unit,
+    bool with_coord, bool with_dist, bool with_hash, bool asc_order, const std::string& store_key,
+    const reply_callback_t& reply_callback);
 
-			client &georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
-			                  bool with_coord, bool with_dist, bool with_hash, bool asc_order, const std::string &store_key,
-			                  const std::string &storedist_key, const reply_callback_t &reply_callback);
+  client& georadius(const std::string& key, double longitude, double latitude, double radius, geo_unit unit,
+    bool with_coord, bool with_dist, bool with_hash, bool asc_order, const std::string& store_key,
+    const std::string& storedist_key, const reply_callback_t& reply_callback);
 
-			client &georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
-			                  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
-			                  const std::string &store_key, const reply_callback_t &reply_callback);
+  client& georadius(const std::string& key, double longitude, double latitude, double radius, geo_unit unit,
+    bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
+    const std::string& store_key, const reply_callback_t& reply_callback);
 
-			client &georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
-			                  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
-			                  const std::string &store_key, const std::string &storedist_key,
-			                  const reply_callback_t &reply_callback);
+  client& georadius(const std::string& key, double longitude, double latitude, double radius, geo_unit unit,
+    bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
+    const std::string& store_key, const std::string& storedist_key,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
-			          bool with_coord = false, bool with_dist = false, bool with_hash = false, bool asc_order = false,
-			          std::size_t count = 0, const std::string &store_key = "", const std::string &storedist_key = "");
+  std::future<reply>
+  georadius(const std::string& key, double longitude, double latitude, double radius, geo_unit unit,
+    bool with_coord = false, bool with_dist = false, bool with_hash = false, bool asc_order = false,
+    std::size_t count = 0, const std::string& store_key = "", const std::string& storedist_key = "");
 
-			client &georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
-			                          bool with_coord, bool with_dist, bool with_hash, bool asc_order,
-			                          const reply_callback_t &reply_callback);
+  client& georadiusbymember(const std::string& key, const std::string& member, double radius, geo_unit unit,
+    bool with_coord, bool with_dist, bool with_hash, bool asc_order,
+    const reply_callback_t& reply_callback);
 
-			client &georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
-			                          bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
-			                          const reply_callback_t &reply_callback);
+  client& georadiusbymember(const std::string& key, const std::string& member, double radius, geo_unit unit,
+    bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
+    const reply_callback_t& reply_callback);
 
-			client &georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
-			                          bool with_coord, bool with_dist, bool with_hash, bool asc_order,
-			                          const std::string &store_key, const reply_callback_t &reply_callback);
+  client& georadiusbymember(const std::string& key, const std::string& member, double radius, geo_unit unit,
+    bool with_coord, bool with_dist, bool with_hash, bool asc_order,
+    const std::string& store_key, const reply_callback_t& reply_callback);
 
-			client &georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
-			                          bool with_coord, bool with_dist, bool with_hash, bool asc_order,
-			                          const std::string &store_key, const std::string &storedist_key,
-			                          const reply_callback_t &reply_callback);
+  client& georadiusbymember(const std::string& key, const std::string& member, double radius, geo_unit unit,
+    bool with_coord, bool with_dist, bool with_hash, bool asc_order,
+    const std::string& store_key, const std::string& storedist_key,
+    const reply_callback_t& reply_callback);
 
-			client &georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
-			                          bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
-			                          const std::string &store_key, const reply_callback_t &reply_callback);
+  client& georadiusbymember(const std::string& key, const std::string& member, double radius, geo_unit unit,
+    bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
+    const std::string& store_key, const reply_callback_t& reply_callback);
 
-			client &georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
-			                          bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
-			                          const std::string &store_key, const std::string &storedist_key,
-			                          const reply_callback_t &reply_callback);
+  client& georadiusbymember(const std::string& key, const std::string& member, double radius, geo_unit unit,
+    bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
+    const std::string& store_key, const std::string& storedist_key,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
-			                  bool with_coord = false, bool with_dist = false, bool with_hash = false, bool asc_order = false,
-			                  std::size_t count = 0, const std::string &store_key = "",
-			                  const std::string &storedist_key = "");
+  std::future<reply>
+  georadiusbymember(const std::string& key, const std::string& member, double radius, geo_unit unit,
+    bool with_coord = false, bool with_dist = false, bool with_hash = false, bool asc_order = false,
+    std::size_t count = 0, const std::string& store_key = "",
+    const std::string& storedist_key = "");
 
-			client &get(const std::string &key, const reply_callback_t &reply_callback);
+  client& get(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> get(const std::string &key);
+  std::future<reply> get(const std::string& key);
 
-			client &getbit(const std::string &key, int offset, const reply_callback_t &reply_callback);
+  client& getbit(const std::string& key, int offset, const reply_callback_t& reply_callback);
 
-			std::future<reply> getbit(const std::string &key, int offset);
+  std::future<reply> getbit(const std::string& key, int offset);
 
-			client &getrange(const std::string &key, int start, int end, const reply_callback_t &reply_callback);
+  client& getrange(const std::string& key, int start, int end, const reply_callback_t& reply_callback);
 
-			std::future<reply> getrange(const std::string &key, int start, int end);
+  std::future<reply> getrange(const std::string& key, int start, int end);
 
-			client &getset(const std::string &key, const std::string &val, const reply_callback_t &reply_callback);
+  client& getset(const std::string& key, const std::string& val, const reply_callback_t& reply_callback);
 
-			std::future<reply> getset(const std::string &key, const std::string &val);
+  std::future<reply> getset(const std::string& key, const std::string& val);
 
-			client &
-			hdel(const std::string &key, const std::vector<std::string> &fields, const reply_callback_t &reply_callback);
+  client&
+  hdel(const std::string& key, const std::vector<std::string>& fields, const reply_callback_t& reply_callback);
 
-			std::future<reply> hdel(const std::string &key, const std::vector<std::string> &fields);
+  std::future<reply> hdel(const std::string& key, const std::vector<std::string>& fields);
 
-			client &hexists(const std::string &key, const std::string &field, const reply_callback_t &reply_callback);
+  client& hexists(const std::string& key, const std::string& field, const reply_callback_t& reply_callback);
 
-			std::future<reply> hexists(const std::string &key, const std::string &field);
+  std::future<reply> hexists(const std::string& key, const std::string& field);
 
-			client &hget(const std::string &key, const std::string &field, const reply_callback_t &reply_callback);
+  client& hget(const std::string& key, const std::string& field, const reply_callback_t& reply_callback);
 
-			std::future<reply> hget(const std::string &key, const std::string &field);
+  std::future<reply> hget(const std::string& key, const std::string& field);
 
-			client &hgetall(const std::string &key, const reply_callback_t &reply_callback);
+  client& hgetall(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> hgetall(const std::string &key);
+  std::future<reply> hgetall(const std::string& key);
 
-			client &
-			hincrby(const std::string &key, const std::string &field, int incr, const reply_callback_t &reply_callback);
+  client&
+  hincrby(const std::string& key, const std::string& field, int incr, const reply_callback_t& reply_callback);
 
-			std::future<reply> hincrby(const std::string &key, const std::string &field, int incr);
+  std::future<reply> hincrby(const std::string& key, const std::string& field, int incr);
 
-			client &hincrbyfloat(const std::string &key, const std::string &field, float incr,
-			                     const reply_callback_t &reply_callback);
+  client& hincrbyfloat(const std::string& key, const std::string& field, float incr,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> hincrbyfloat(const std::string &key, const std::string &field, float incr);
+  std::future<reply> hincrbyfloat(const std::string& key, const std::string& field, float incr);
 
-			client &hkeys(const std::string &key, const reply_callback_t &reply_callback);
+  client& hkeys(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> hkeys(const std::string &key);
+  std::future<reply> hkeys(const std::string& key);
 
-			client &hlen(const std::string &key, const reply_callback_t &reply_callback);
+  client& hlen(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> hlen(const std::string &key);
+  std::future<reply> hlen(const std::string& key);
 
-			client &
-			hmget(const std::string &key, const std::vector<std::string> &fields, const reply_callback_t &reply_callback);
+  client&
+  hmget(const std::string& key, const std::vector<std::string>& fields, const reply_callback_t& reply_callback);
 
-			std::future<reply> hmget(const std::string &key, const std::vector<std::string> &fields);
+  std::future<reply> hmget(const std::string& key, const std::vector<std::string>& fields);
 
-			client &hmset(const std::string &key, const std::vector<std::pair<std::string, std::string>> &field_val,
-			              const reply_callback_t &reply_callback);
+  client& hmset(const std::string& key, const std::vector<std::pair<std::string, std::string>>& field_val,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			hmset(const std::string &key, const std::vector<std::pair<std::string, std::string>> &field_val);
+  std::future<reply>
+  hmset(const std::string& key, const std::vector<std::pair<std::string, std::string>>& field_val);
 
-			client &hscan(const std::string &key, std::size_t cursor, const reply_callback_t &reply_callback);
+  client& hscan(const std::string& key, std::size_t cursor, const reply_callback_t& reply_callback);
 
-			std::future<reply> hscan(const std::string &key, std::size_t cursor);
+  std::future<reply> hscan(const std::string& key, std::size_t cursor);
 
-			client &hscan(const std::string &key, std::size_t cursor, const std::string &pattern,
-			              const reply_callback_t &reply_callback);
+  client& hscan(const std::string& key, std::size_t cursor, const std::string& pattern,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> hscan(const std::string &key, std::size_t cursor, const std::string &pattern);
+  std::future<reply> hscan(const std::string& key, std::size_t cursor, const std::string& pattern);
 
-			client &
-			hscan(const std::string &key, std::size_t cursor, std::size_t count, const reply_callback_t &reply_callback);
+  client&
+  hscan(const std::string& key, std::size_t cursor, std::size_t count, const reply_callback_t& reply_callback);
 
-			std::future<reply> hscan(const std::string &key, std::size_t cursor, std::size_t count);
+  std::future<reply> hscan(const std::string& key, std::size_t cursor, std::size_t count);
 
-			client &hscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count,
-			              const reply_callback_t &reply_callback);
+  client& hscan(const std::string& key, std::size_t cursor, const std::string& pattern, std::size_t count,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			hscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count);
+  std::future<reply>
+  hscan(const std::string& key, std::size_t cursor, const std::string& pattern, std::size_t count);
 
-			client &hset(const std::string &key, const std::string &field, const std::string &value,
-			             const reply_callback_t &reply_callback);
+  client& hset(const std::string& key, const std::string& field, const std::string& value,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> hset(const std::string &key, const std::string &field, const std::string &value);
+  std::future<reply> hset(const std::string& key, const std::string& field, const std::string& value);
 
-			client &hsetnx(const std::string &key, const std::string &field, const std::string &value,
-			               const reply_callback_t &reply_callback);
+  client& hsetnx(const std::string& key, const std::string& field, const std::string& value,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> hsetnx(const std::string &key, const std::string &field, const std::string &value);
+  std::future<reply> hsetnx(const std::string& key, const std::string& field, const std::string& value);
 
-			client &hstrlen(const std::string &key, const std::string &field, const reply_callback_t &reply_callback);
+  client& hstrlen(const std::string& key, const std::string& field, const reply_callback_t& reply_callback);
 
-			std::future<reply> hstrlen(const std::string &key, const std::string &field);
+  std::future<reply> hstrlen(const std::string& key, const std::string& field);
 
-			client &hvals(const std::string &key, const reply_callback_t &reply_callback);
+  client& hvals(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> hvals(const std::string &key);
+  std::future<reply> hvals(const std::string& key);
 
-			client &incr(const std::string &key, const reply_callback_t &reply_callback);
+  client& incr(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> incr(const std::string &key);
+  std::future<reply> incr(const std::string& key);
 
-			client &incrby(const std::string &key, int incr, const reply_callback_t &reply_callback);
+  client& incrby(const std::string& key, int incr, const reply_callback_t& reply_callback);
 
-			std::future<reply> incrby(const std::string &key, int incr);
+  std::future<reply> incrby(const std::string& key, int incr);
 
-			client &incrbyfloat(const std::string &key, float incr, const reply_callback_t &reply_callback);
+  client& incrbyfloat(const std::string& key, float incr, const reply_callback_t& reply_callback);
 
-			std::future<reply> incrbyfloat(const std::string &key, float incr);
+  std::future<reply> incrbyfloat(const std::string& key, float incr);
 
-			client &info(const reply_callback_t &reply_callback);
+  client& info(const reply_callback_t& reply_callback);
 
-			client &info(const std::string &section, const reply_callback_t &reply_callback);
+  client& info(const std::string& section, const reply_callback_t& reply_callback);
 
-			std::future<reply> info(const std::string &section = "default");
+  std::future<reply> info(const std::string& section = "default");
 
-			client &keys(const std::string &pattern, const reply_callback_t &reply_callback);
+  client& keys(const std::string& pattern, const reply_callback_t& reply_callback);
 
-			std::future<reply> keys(const std::string &pattern);
+  std::future<reply> keys(const std::string& pattern);
 
-			client &lastsave(const reply_callback_t &reply_callback);
+  client& lastsave(const reply_callback_t& reply_callback);
 
-			std::future<reply> lastsave();
+  std::future<reply> lastsave();
 
-			client &lindex(const std::string &key, int index, const reply_callback_t &reply_callback);
+  client& lindex(const std::string& key, int index, const reply_callback_t& reply_callback);
 
-			std::future<reply> lindex(const std::string &key, int index);
+  std::future<reply> lindex(const std::string& key, int index);
 
-			client &linsert(const std::string &key, const std::string &before_after, const std::string &pivot,
-			                const std::string &value, const reply_callback_t &reply_callback);
+  client& linsert(const std::string& key, const std::string& before_after, const std::string& pivot,
+    const std::string& value, const reply_callback_t& reply_callback);
 
-			std::future<reply> linsert(const std::string &key, const std::string &before_after, const std::string &pivot,
-			                           const std::string &value);
+  std::future<reply> linsert(const std::string& key, const std::string& before_after, const std::string& pivot,
+    const std::string& value);
 
-			client &llen(const std::string &key, const reply_callback_t &reply_callback);
+  client& llen(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> llen(const std::string &key);
+  std::future<reply> llen(const std::string& key);
 
-			client &lpop(const std::string &key, const reply_callback_t &reply_callback);
+  client& lpop(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> lpop(const std::string &key);
+  std::future<reply> lpop(const std::string& key);
 
-			client &
-			lpush(const std::string &key, const std::vector<std::string> &values, const reply_callback_t &reply_callback);
+  client&
+  lpush(const std::string& key, const std::vector<std::string>& values, const reply_callback_t& reply_callback);
 
-			std::future<reply> lpush(const std::string &key, const std::vector<std::string> &values);
+  std::future<reply> lpush(const std::string& key, const std::vector<std::string>& values);
 
-			client &lpushx(const std::string &key, const std::string &value, const reply_callback_t &reply_callback);
+  client& lpushx(const std::string& key, const std::string& value, const reply_callback_t& reply_callback);
 
-			std::future<reply> lpushx(const std::string &key, const std::string &value);
+  std::future<reply> lpushx(const std::string& key, const std::string& value);
 
-			client &lrange(const std::string &key, int start, int stop, const reply_callback_t &reply_callback);
+  client& lrange(const std::string& key, int start, int stop, const reply_callback_t& reply_callback);
 
-			std::future<reply> lrange(const std::string &key, int start, int stop);
+  std::future<reply> lrange(const std::string& key, int start, int stop);
 
-			client &lrem(const std::string &key, int count, const std::string &value, const reply_callback_t &reply_callback);
+  client& lrem(const std::string& key, int count, const std::string& value, const reply_callback_t& reply_callback);
 
-			std::future<reply> lrem(const std::string &key, int count, const std::string &value);
+  std::future<reply> lrem(const std::string& key, int count, const std::string& value);
 
-			client &lset(const std::string &key, int index, const std::string &value, const reply_callback_t &reply_callback);
+  client& lset(const std::string& key, int index, const std::string& value, const reply_callback_t& reply_callback);
 
-			std::future<reply> lset(const std::string &key, int index, const std::string &value);
+  std::future<reply> lset(const std::string& key, int index, const std::string& value);
 
-			client &ltrim(const std::string &key, int start, int stop, const reply_callback_t &reply_callback);
+  client& ltrim(const std::string& key, int start, int stop, const reply_callback_t& reply_callback);
 
-			std::future<reply> ltrim(const std::string &key, int start, int stop);
+  std::future<reply> ltrim(const std::string& key, int start, int stop);
 
-			client &mget(const std::vector<std::string> &keys, const reply_callback_t &reply_callback);
+  client& mget(const std::vector<std::string>& keys, const reply_callback_t& reply_callback);
 
-			std::future<reply> mget(const std::vector<std::string> &keys);
+  std::future<reply> mget(const std::vector<std::string>& keys);
 
-			client &
-			migrate(const std::string &host, int port, const std::string &key, const std::string &dest_db, int timeout,
-			        const reply_callback_t &reply_callback);
+  client&
+  migrate(const std::string& host, int port, const std::string& key, const std::string& dest_db, int timeout,
+    const reply_callback_t& reply_callback);
 
-			client &
-			migrate(const std::string &host, int port, const std::string &key, const std::string &dest_db, int timeout,
-			        bool copy, bool replace, const std::vector<std::string> &keys, const reply_callback_t &reply_callback);
+  client&
+  migrate(const std::string& host, int port, const std::string& key, const std::string& dest_db, int timeout,
+    bool copy, bool replace, const std::vector<std::string>& keys, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			migrate(const std::string &host, int port, const std::string &key, const std::string &dest_db, int timeout,
-			        bool copy = false, bool replace = false, const std::vector<std::string> &keys = {});
+  std::future<reply>
+  migrate(const std::string& host, int port, const std::string& key, const std::string& dest_db, int timeout,
+    bool copy = false, bool replace = false, const std::vector<std::string>& keys = {});
 
-			client &monitor(const reply_callback_t &reply_callback);
+  client& monitor(const reply_callback_t& reply_callback);
 
-			std::future<reply> monitor();
+  std::future<reply> monitor();
 
-			client &move(const std::string &key, const std::string &db, const reply_callback_t &reply_callback);
+  client& move(const std::string& key, const std::string& db, const reply_callback_t& reply_callback);
 
-			std::future<reply> move(const std::string &key, const std::string &db);
+  std::future<reply> move(const std::string& key, const std::string& db);
 
-			client &
-			mset(const std::vector<std::pair<std::string, std::string>> &key_vals, const reply_callback_t &reply_callback);
+  client&
+  mset(const std::vector<std::pair<std::string, std::string>>& key_vals, const reply_callback_t& reply_callback);
 
-			std::future<reply> mset(const std::vector<std::pair<std::string, std::string>> &key_vals);
+  std::future<reply> mset(const std::vector<std::pair<std::string, std::string>>& key_vals);
 
-			client &
-			msetnx(const std::vector<std::pair<std::string, std::string>> &key_vals, const reply_callback_t &reply_callback);
+  client&
+  msetnx(const std::vector<std::pair<std::string, std::string>>& key_vals, const reply_callback_t& reply_callback);
 
-			std::future<reply> msetnx(const std::vector<std::pair<std::string, std::string>> &key_vals);
+  std::future<reply> msetnx(const std::vector<std::pair<std::string, std::string>>& key_vals);
 
-			client &multi(const reply_callback_t &reply_callback);
+  client& multi(const reply_callback_t& reply_callback);
 
-			std::future<reply> multi();
+  std::future<reply> multi();
 
-			client &object(const std::string &subcommand, const std::vector<std::string> &args,
-			               const reply_callback_t &reply_callback);
+  client& object(const std::string& subcommand, const std::vector<std::string>& args,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> object(const std::string &subcommand, const std::vector<std::string> &args);
+  std::future<reply> object(const std::string& subcommand, const std::vector<std::string>& args);
 
-			client &persist(const std::string &key, const reply_callback_t &reply_callback);
+  client& persist(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> persist(const std::string &key);
+  std::future<reply> persist(const std::string& key);
 
-			client &pexpire(const std::string &key, int ms, const reply_callback_t &reply_callback);
+  client& pexpire(const std::string& key, int ms, const reply_callback_t& reply_callback);
 
-			std::future<reply> pexpire(const std::string &key, int ms);
+  std::future<reply> pexpire(const std::string& key, int ms);
 
-			client &pexpireat(const std::string &key, int ms_timestamp, const reply_callback_t &reply_callback);
+  client& pexpireat(const std::string& key, int ms_timestamp, const reply_callback_t& reply_callback);
 
-			std::future<reply> pexpireat(const std::string &key, int ms_timestamp);
+  std::future<reply> pexpireat(const std::string& key, int ms_timestamp);
 
-			client &
-			pfadd(const std::string &key, const std::vector<std::string> &elements, const reply_callback_t &reply_callback);
+  client&
+  pfadd(const std::string& key, const std::vector<std::string>& elements, const reply_callback_t& reply_callback);
 
-			std::future<reply> pfadd(const std::string &key, const std::vector<std::string> &elements);
+  std::future<reply> pfadd(const std::string& key, const std::vector<std::string>& elements);
 
-			client &pfcount(const std::vector<std::string> &keys, const reply_callback_t &reply_callback);
+  client& pfcount(const std::vector<std::string>& keys, const reply_callback_t& reply_callback);
 
-			std::future<reply> pfcount(const std::vector<std::string> &keys);
+  std::future<reply> pfcount(const std::vector<std::string>& keys);
 
-			client &pfmerge(const std::string &destkey, const std::vector<std::string> &sourcekeys,
-			                const reply_callback_t &reply_callback);
+  client& pfmerge(const std::string& destkey, const std::vector<std::string>& sourcekeys,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> pfmerge(const std::string &destkey, const std::vector<std::string> &sourcekeys);
+  std::future<reply> pfmerge(const std::string& destkey, const std::vector<std::string>& sourcekeys);
 
-			client &ping(const reply_callback_t &reply_callback);
+  client& ping(const reply_callback_t& reply_callback);
 
-			std::future<reply> ping();
+  std::future<reply> ping();
 
-			client &ping(const std::string &message, const reply_callback_t &reply_callback);
+  client& ping(const std::string& message, const reply_callback_t& reply_callback);
 
-			std::future<reply> ping(const std::string &message);
+  std::future<reply> ping(const std::string& message);
 
-			client &
-			psetex(const std::string &key, int64_t ms, const std::string &val, const reply_callback_t &reply_callback);
+  client&
+  psetex(const std::string& key, int64_t ms, const std::string& val, const reply_callback_t& reply_callback);
 
-			std::future<reply> psetex(const std::string &key, int64_t ms, const std::string &val);
+  std::future<reply> psetex(const std::string& key, int64_t ms, const std::string& val);
 
-			client &publish(const std::string &channel, const std::string &message, const reply_callback_t &reply_callback);
+  client& publish(const std::string& channel, const std::string& message, const reply_callback_t& reply_callback);
 
-			std::future<reply> publish(const std::string &channel, const std::string &message);
+  std::future<reply> publish(const std::string& channel, const std::string& message);
 
-			client &pubsub(const std::string &subcommand, const std::vector<std::string> &args,
-			               const reply_callback_t &reply_callback);
+  client& pubsub(const std::string& subcommand, const std::vector<std::string>& args,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> pubsub(const std::string &subcommand, const std::vector<std::string> &args);
+  std::future<reply> pubsub(const std::string& subcommand, const std::vector<std::string>& args);
 
-			client &pttl(const std::string &key, const reply_callback_t &reply_callback);
+  client& pttl(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> pttl(const std::string &key);
+  std::future<reply> pttl(const std::string& key);
 
-			client &quit(const reply_callback_t &reply_callback);
+  client& quit(const reply_callback_t& reply_callback);
 
-			std::future<reply> quit();
+  std::future<reply> quit();
 
-			client &randomkey(const reply_callback_t &reply_callback);
+  client& randomkey(const reply_callback_t& reply_callback);
 
-			std::future<reply> randomkey();
+  std::future<reply> randomkey();
 
-			client &readonly(const reply_callback_t &reply_callback);
+  client& readonly(const reply_callback_t& reply_callback);
 
-			std::future<reply> readonly();
+  std::future<reply> readonly();
 
-			client &readwrite(const reply_callback_t &reply_callback);
+  client& readwrite(const reply_callback_t& reply_callback);
 
-			std::future<reply> readwrite();
+  std::future<reply> readwrite();
 
-			client &rename(const std::string &key, const std::string &newkey, const reply_callback_t &reply_callback);
+  client& rename(const std::string& key, const std::string& newkey, const reply_callback_t& reply_callback);
 
-			std::future<reply> rename(const std::string &key, const std::string &newkey);
+  std::future<reply> rename(const std::string& key, const std::string& newkey);
 
-			client &renamenx(const std::string &key, const std::string &newkey, const reply_callback_t &reply_callback);
+  client& renamenx(const std::string& key, const std::string& newkey, const reply_callback_t& reply_callback);
 
-			std::future<reply> renamenx(const std::string &key, const std::string &newkey);
+  std::future<reply> renamenx(const std::string& key, const std::string& newkey);
 
-			client &restore(const std::string &key, int ttl, const std::string &serialized_value,
-			                const reply_callback_t &reply_callback);
+  client& restore(const std::string& key, int ttl, const std::string& serialized_value,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> restore(const std::string &key, int ttl, const std::string &serialized_value);
+  std::future<reply> restore(const std::string& key, int ttl, const std::string& serialized_value);
 
-			client &restore(const std::string &key, int ttl, const std::string &serialized_value, const std::string &replace,
-			                const reply_callback_t &reply_callback);
+  client& restore(const std::string& key, int ttl, const std::string& serialized_value, const std::string& replace,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			restore(const std::string &key, int ttl, const std::string &serialized_value, const std::string &replace);
+  std::future<reply>
+  restore(const std::string& key, int ttl, const std::string& serialized_value, const std::string& replace);
 
-			client &role(const reply_callback_t &reply_callback);
+  client& role(const reply_callback_t& reply_callback);
 
-			std::future<reply> role();
+  std::future<reply> role();
 
-			client &rpop(const std::string &key, const reply_callback_t &reply_callback);
+  client& rpop(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> rpop(const std::string &key);
+  std::future<reply> rpop(const std::string& key);
 
-			client &
-			rpoplpush(const std::string &source, const std::string &destination, const reply_callback_t &reply_callback);
+  client&
+  rpoplpush(const std::string& source, const std::string& destination, const reply_callback_t& reply_callback);
 
-			std::future<reply> rpoplpush(const std::string &src, const std::string &dst);
+  std::future<reply> rpoplpush(const std::string& src, const std::string& dst);
 
-			client &
-			rpush(const std::string &key, const std::vector<std::string> &values, const reply_callback_t &reply_callback);
+  client&
+  rpush(const std::string& key, const std::vector<std::string>& values, const reply_callback_t& reply_callback);
 
-			std::future<reply> rpush(const std::string &key, const std::vector<std::string> &values);
+  std::future<reply> rpush(const std::string& key, const std::vector<std::string>& values);
 
-			client &rpushx(const std::string &key, const std::string &value, const reply_callback_t &reply_callback);
+  client& rpushx(const std::string& key, const std::string& value, const reply_callback_t& reply_callback);
 
-			std::future<reply> rpushx(const std::string &key, const std::string &value);
+  std::future<reply> rpushx(const std::string& key, const std::string& value);
 
-			client &
-			sadd(const std::string &key, const std::vector<std::string> &members, const reply_callback_t &reply_callback);
+  client&
+  sadd(const std::string& key, const std::vector<std::string>& members, const reply_callback_t& reply_callback);
 
-			std::future<reply> sadd(const std::string &key, const std::vector<std::string> &members);
+  std::future<reply> sadd(const std::string& key, const std::vector<std::string>& members);
 
-			client &save(const reply_callback_t &reply_callback);
+  client& save(const reply_callback_t& reply_callback);
 
-			std::future<reply> save();
+  std::future<reply> save();
 
-			client &scan(std::size_t cursor, const reply_callback_t &reply_callback);
+  client& scan(std::size_t cursor, const reply_callback_t& reply_callback);
 
-			std::future<reply> scan(std::size_t cursor);
+  std::future<reply> scan(std::size_t cursor);
 
-			client &scan(std::size_t cursor, const std::string &pattern, const reply_callback_t &reply_callback);
+  client& scan(std::size_t cursor, const std::string& pattern, const reply_callback_t& reply_callback);
 
-			std::future<reply> scan(std::size_t cursor, const std::string &pattern);
+  std::future<reply> scan(std::size_t cursor, const std::string& pattern);
 
-			client &scan(std::size_t cursor, std::size_t count, const reply_callback_t &reply_callback);
+  client& scan(std::size_t cursor, std::size_t count, const reply_callback_t& reply_callback);
 
-			std::future<reply> scan(std::size_t cursor, std::size_t count);
+  std::future<reply> scan(std::size_t cursor, std::size_t count);
 
-			client &
-			scan(std::size_t cursor, const std::string &pattern, std::size_t count, const reply_callback_t &reply_callback);
+  client&
+  scan(std::size_t cursor, const std::string& pattern, std::size_t count, const reply_callback_t& reply_callback);
 
-			std::future<reply> scan(std::size_t cursor, const std::string &pattern, std::size_t count);
+  std::future<reply> scan(std::size_t cursor, const std::string& pattern, std::size_t count);
 
-			client &scard(const std::string &key, const reply_callback_t &reply_callback);
+  client& scard(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> scard(const std::string &key);
+  std::future<reply> scard(const std::string& key);
 
-			client &script_debug(const std::string &mode, const reply_callback_t &reply_callback);
+  client& script_debug(const std::string& mode, const reply_callback_t& reply_callback);
 
-			std::future<reply> script_debug(const std::string &mode);
+  std::future<reply> script_debug(const std::string& mode);
 
-			client &script_exists(const std::vector<std::string> &scripts, const reply_callback_t &reply_callback);
+  client& script_exists(const std::vector<std::string>& scripts, const reply_callback_t& reply_callback);
 
-			std::future<reply> script_exists(const std::vector<std::string> &scripts);
+  std::future<reply> script_exists(const std::vector<std::string>& scripts);
 
-			client &script_flush(const reply_callback_t &reply_callback);
+  client& script_flush(const reply_callback_t& reply_callback);
 
-			std::future<reply> script_flush();
+  std::future<reply> script_flush();
 
-			client &script_kill(const reply_callback_t &reply_callback);
+  client& script_kill(const reply_callback_t& reply_callback);
 
-			std::future<reply> script_kill();
+  std::future<reply> script_kill();
 
-			client &script_load(const std::string &script, const reply_callback_t &reply_callback);
+  client& script_load(const std::string& script, const reply_callback_t& reply_callback);
 
-			std::future<reply> script_load(const std::string &script);
+  std::future<reply> script_load(const std::string& script);
 
-			client &sdiff(const std::vector<std::string> &keys, const reply_callback_t &reply_callback);
+  client& sdiff(const std::vector<std::string>& keys, const reply_callback_t& reply_callback);
 
-			std::future<reply> sdiff(const std::vector<std::string> &keys);
+  std::future<reply> sdiff(const std::vector<std::string>& keys);
 
-			client &sdiffstore(const std::string &destination, const std::vector<std::string> &keys,
-			                   const reply_callback_t &reply_callback);
+  client& sdiffstore(const std::string& destination, const std::vector<std::string>& keys,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> sdiffstore(const std::string &dst, const std::vector<std::string> &keys);
+  std::future<reply> sdiffstore(const std::string& dst, const std::vector<std::string>& keys);
 
-			client &select(int index, const reply_callback_t &reply_callback);
+  client& select(int index, const reply_callback_t& reply_callback);
 
-			std::future<reply> select(int index);
+  std::future<reply> select(int index);
 
-			client &set(const std::string &key, const std::string &value, const reply_callback_t &reply_callback);
+  client& set(const std::string& key, const std::string& value, const reply_callback_t& reply_callback);
 
-			std::future<reply> set(const std::string &key, const std::string &value);
+  std::future<reply> set(const std::string& key, const std::string& value);
 
-			client &set_advanced(const std::string &key, const std::string &value, const reply_callback_t &reply_callback);
+  client& set_advanced(const std::string& key, const std::string& value, const reply_callback_t& reply_callback);
 
-			client &set_advanced(const std::string &key, const std::string &value, bool ex, int ex_sec, bool px, int px_milli,
-			                     bool nx, bool xx, const reply_callback_t &reply_callback);
+  client& set_advanced(const std::string& key, const std::string& value, bool ex, int ex_sec, bool px, int px_milli,
+    bool nx, bool xx, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			set_advanced(const std::string &key, const std::string &value, bool ex = false, int ex_sec = 0, bool px = false,
-			             int px_milli = 0, bool nx = false, bool xx = false);
+  std::future<reply>
+  set_advanced(const std::string& key, const std::string& value, bool ex = false, int ex_sec = 0, bool px = false,
+    int px_milli = 0, bool nx = false, bool xx = false);
 
-			client &
-			setbit_(const std::string &key, int offset, const std::string &value, const reply_callback_t &reply_callback);
+  client&
+  setbit_(const std::string& key, int offset, const std::string& value, const reply_callback_t& reply_callback);
 
-			std::future<reply> setbit_(const std::string &key, int offset, const std::string &value);
+  std::future<reply> setbit_(const std::string& key, int offset, const std::string& value);
 
-			client &
-			setex(const std::string &key, int64_t seconds, const std::string &value, const reply_callback_t &reply_callback);
+  client&
+  setex(const std::string& key, int64_t seconds, const std::string& value, const reply_callback_t& reply_callback);
 
-			std::future<reply> setex(const std::string &key, int64_t seconds, const std::string &value);
+  std::future<reply> setex(const std::string& key, int64_t seconds, const std::string& value);
 
-			client &setnx(const std::string &key, const std::string &value, const reply_callback_t &reply_callback);
+  client& setnx(const std::string& key, const std::string& value, const reply_callback_t& reply_callback);
 
-			std::future<reply> setnx(const std::string &key, const std::string &value);
+  std::future<reply> setnx(const std::string& key, const std::string& value);
 
-			client &
-			setrange(const std::string &key, int offset, const std::string &value, const reply_callback_t &reply_callback);
+  client&
+  setrange(const std::string& key, int offset, const std::string& value, const reply_callback_t& reply_callback);
 
-			std::future<reply> setrange(const std::string &key, int offset, const std::string &value);
+  std::future<reply> setrange(const std::string& key, int offset, const std::string& value);
 
-			client &shutdown(const reply_callback_t &reply_callback);
+  client& shutdown(const reply_callback_t& reply_callback);
 
-			std::future<reply> shutdown();
+  std::future<reply> shutdown();
 
-			client &shutdown(const std::string &save, const reply_callback_t &reply_callback);
+  client& shutdown(const std::string& save, const reply_callback_t& reply_callback);
 
-			std::future<reply> shutdown(const std::string &save);
+  std::future<reply> shutdown(const std::string& save);
 
-			client &sinter(const std::vector<std::string> &keys, const reply_callback_t &reply_callback);
+  client& sinter(const std::vector<std::string>& keys, const reply_callback_t& reply_callback);
 
-			std::future<reply> sinter(const std::vector<std::string> &keys);
+  std::future<reply> sinter(const std::vector<std::string>& keys);
 
-			client &sinterstore(const std::string &destination, const std::vector<std::string> &keys,
-			                    const reply_callback_t &reply_callback);
+  client& sinterstore(const std::string& destination, const std::vector<std::string>& keys,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> sinterstore(const std::string &dst, const std::vector<std::string> &keys);
+  std::future<reply> sinterstore(const std::string& dst, const std::vector<std::string>& keys);
 
-			client &sismember(const std::string &key, const std::string &member, const reply_callback_t &reply_callback);
+  client& sismember(const std::string& key, const std::string& member, const reply_callback_t& reply_callback);
 
-			std::future<reply> sismember(const std::string &key, const std::string &member);
+  std::future<reply> sismember(const std::string& key, const std::string& member);
 
-			client &slaveof(const std::string &host, int port, const reply_callback_t &reply_callback);
+  client& slaveof(const std::string& host, int port, const reply_callback_t& reply_callback);
 
-			std::future<reply> slaveof(const std::string &host, int port);
+  std::future<reply> slaveof(const std::string& host, int port);
 
-			client &slowlog(std::string subcommand, const reply_callback_t &reply_callback);
+  client& slowlog(std::string subcommand, const reply_callback_t& reply_callback);
 
-			std::future<reply> slowlog(const std::string &subcommand);
+  std::future<reply> slowlog(const std::string& subcommand);
 
-			client &
-			slowlog(std::string subcommand, const std::string &argument, const reply_callback_t &reply_callback);
+  client&
+  slowlog(std::string subcommand, const std::string& argument, const reply_callback_t& reply_callback);
 
-			std::future<reply> slowlog(const std::string &subcommand, const std::string &argument);
+  std::future<reply> slowlog(const std::string& subcommand, const std::string& argument);
 
-			client &smembers(const std::string &key, const reply_callback_t &reply_callback);
+  client& smembers(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> smembers(const std::string &key);
+  std::future<reply> smembers(const std::string& key);
 
-			client &smove(const std::string &source, const std::string &destination, const std::string &member,
-			              const reply_callback_t &reply_callback);
+  client& smove(const std::string& source, const std::string& destination, const std::string& member,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> smove(const std::string &src, const std::string &dst, const std::string &member);
+  std::future<reply> smove(const std::string& src, const std::string& dst, const std::string& member);
 
-			client &sort(const std::string &key, const reply_callback_t &reply_callback);
+  client& sort(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> sort(const std::string &key);
+  std::future<reply> sort(const std::string& key);
 
-			client &sort(const std::string &key, const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
-			             const reply_callback_t &reply_callback);
+  client& sort(const std::string& key, const std::vector<std::string>& get_patterns, bool asc_order, bool alpha,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			sort(const std::string &key, const std::vector<std::string> &get_patterns, bool asc_order, bool alpha);
+  std::future<reply>
+  sort(const std::string& key, const std::vector<std::string>& get_patterns, bool asc_order, bool alpha);
 
-			client &
-			sort(const std::string &key, std::size_t offset, std::size_t count, const std::vector<std::string> &get_patterns,
-			     bool asc_order, bool alpha, const reply_callback_t &reply_callback);
+  client&
+  sort(const std::string& key, std::size_t offset, std::size_t count, const std::vector<std::string>& get_patterns,
+    bool asc_order, bool alpha, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			sort(const std::string &key, std::size_t offset, std::size_t count, const std::vector<std::string> &get_patterns,
-			     bool asc_order, bool alpha);
+  std::future<reply>
+  sort(const std::string& key, std::size_t offset, std::size_t count, const std::vector<std::string>& get_patterns,
+    bool asc_order, bool alpha);
 
-			client &sort(const std::string &key, const std::string &by_pattern, const std::vector<std::string> &get_patterns,
-			             bool asc_order, bool alpha, const reply_callback_t &reply_callback);
+  client& sort(const std::string& key, const std::string& by_pattern, const std::vector<std::string>& get_patterns,
+    bool asc_order, bool alpha, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			sort(const std::string &key, const std::string &by_pattern, const std::vector<std::string> &get_patterns,
-			     bool asc_order, bool alpha);
+  std::future<reply>
+  sort(const std::string& key, const std::string& by_pattern, const std::vector<std::string>& get_patterns,
+    bool asc_order, bool alpha);
 
-			client &sort(const std::string &key, const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
-			             const std::string &store_dest, const reply_callback_t &reply_callback);
+  client& sort(const std::string& key, const std::vector<std::string>& get_patterns, bool asc_order, bool alpha,
+    const std::string& store_dest, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			sort(const std::string &key, const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
-			     const std::string &store_dest);
+  std::future<reply>
+  sort(const std::string& key, const std::vector<std::string>& get_patterns, bool asc_order, bool alpha,
+    const std::string& store_dest);
 
-			client &
-			sort(const std::string &key, std::size_t offset, std::size_t count, const std::vector<std::string> &get_patterns,
-			     bool asc_order, bool alpha, const std::string &store_dest, const reply_callback_t &reply_callback);
+  client&
+  sort(const std::string& key, std::size_t offset, std::size_t count, const std::vector<std::string>& get_patterns,
+    bool asc_order, bool alpha, const std::string& store_dest, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			sort(const std::string &key, std::size_t offset, std::size_t count, const std::vector<std::string> &get_patterns,
-			     bool asc_order, bool alpha, const std::string &store_dest);
+  std::future<reply>
+  sort(const std::string& key, std::size_t offset, std::size_t count, const std::vector<std::string>& get_patterns,
+    bool asc_order, bool alpha, const std::string& store_dest);
 
-			client &sort(const std::string &key, const std::string &by_pattern, const std::vector<std::string> &get_patterns,
-			             bool asc_order, bool alpha, const std::string &store_dest, const reply_callback_t &reply_callback);
+  client& sort(const std::string& key, const std::string& by_pattern, const std::vector<std::string>& get_patterns,
+    bool asc_order, bool alpha, const std::string& store_dest, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			sort(const std::string &key, const std::string &by_pattern, const std::vector<std::string> &get_patterns,
-			     bool asc_order, bool alpha, const std::string &store_dest);
+  std::future<reply>
+  sort(const std::string& key, const std::string& by_pattern, const std::vector<std::string>& get_patterns,
+    bool asc_order, bool alpha, const std::string& store_dest);
 
-			client &sort(const std::string &key, const std::string &by_pattern, std::size_t offset, std::size_t count,
-			             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
-			             const reply_callback_t &reply_callback);
+  client& sort(const std::string& key, const std::string& by_pattern, std::size_t offset, std::size_t count,
+    const std::vector<std::string>& get_patterns, bool asc_order, bool alpha,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			sort(const std::string &key, const std::string &by_pattern, std::size_t offset, std::size_t count,
-			     const std::vector<std::string> &get_patterns, bool asc_order, bool alpha);
+  std::future<reply>
+  sort(const std::string& key, const std::string& by_pattern, std::size_t offset, std::size_t count,
+    const std::vector<std::string>& get_patterns, bool asc_order, bool alpha);
 
-			client &sort(const std::string &key, const std::string &by_pattern, std::size_t offset, std::size_t count,
-			             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
-			             const std::string &store_dest, const reply_callback_t &reply_callback);
+  client& sort(const std::string& key, const std::string& by_pattern, std::size_t offset, std::size_t count,
+    const std::vector<std::string>& get_patterns, bool asc_order, bool alpha,
+    const std::string& store_dest, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			sort(const std::string &key, const std::string &by_pattern, std::size_t offset, std::size_t count,
-			     const std::vector<std::string> &get_patterns, bool asc_order, bool alpha, const std::string &store_dest);
+  std::future<reply>
+  sort(const std::string& key, const std::string& by_pattern, std::size_t offset, std::size_t count,
+    const std::vector<std::string>& get_patterns, bool asc_order, bool alpha, const std::string& store_dest);
 
-			client &spop(const std::string &key, const reply_callback_t &reply_callback);
+  client& spop(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> spop(const std::string &key);
+  std::future<reply> spop(const std::string& key);
 
-			client &spop(const std::string &key, int count, const reply_callback_t &reply_callback);
+  client& spop(const std::string& key, int count, const reply_callback_t& reply_callback);
 
-			std::future<reply> spop(const std::string &key, int count);
+  std::future<reply> spop(const std::string& key, int count);
 
-			client &srandmember(const std::string &key, const reply_callback_t &reply_callback);
+  client& srandmember(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> srandmember(const std::string &key);
+  std::future<reply> srandmember(const std::string& key);
 
-			client &srandmember(const std::string &key, int count, const reply_callback_t &reply_callback);
+  client& srandmember(const std::string& key, int count, const reply_callback_t& reply_callback);
 
-			std::future<reply> srandmember(const std::string &key, int count);
+  std::future<reply> srandmember(const std::string& key, int count);
 
-			client &
-			srem(const std::string &key, const std::vector<std::string> &members, const reply_callback_t &reply_callback);
+  client&
+  srem(const std::string& key, const std::vector<std::string>& members, const reply_callback_t& reply_callback);
 
-			std::future<reply> srem(const std::string &key, const std::vector<std::string> &members);
+  std::future<reply> srem(const std::string& key, const std::vector<std::string>& members);
 
-			client &sscan(const std::string &key, std::size_t cursor, const reply_callback_t &reply_callback);
+  client& sscan(const std::string& key, std::size_t cursor, const reply_callback_t& reply_callback);
 
-			std::future<reply> sscan(const std::string &key, std::size_t cursor);
+  std::future<reply> sscan(const std::string& key, std::size_t cursor);
 
-			client &sscan(const std::string &key, std::size_t cursor, const std::string &pattern,
-			              const reply_callback_t &reply_callback);
+  client& sscan(const std::string& key, std::size_t cursor, const std::string& pattern,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> sscan(const std::string &key, std::size_t cursor, const std::string &pattern);
+  std::future<reply> sscan(const std::string& key, std::size_t cursor, const std::string& pattern);
 
-			client &
-			sscan(const std::string &key, std::size_t cursor, std::size_t count, const reply_callback_t &reply_callback);
+  client&
+  sscan(const std::string& key, std::size_t cursor, std::size_t count, const reply_callback_t& reply_callback);
 
-			std::future<reply> sscan(const std::string &key, std::size_t cursor, std::size_t count);
+  std::future<reply> sscan(const std::string& key, std::size_t cursor, std::size_t count);
 
-			client &sscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count,
-			              const reply_callback_t &reply_callback);
+  client& sscan(const std::string& key, std::size_t cursor, const std::string& pattern, std::size_t count,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			sscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count);
+  std::future<reply>
+  sscan(const std::string& key, std::size_t cursor, const std::string& pattern, std::size_t count);
 
-			client &strlen(const std::string &key, const reply_callback_t &reply_callback);
+  client& strlen(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> strlen(const std::string &key);
+  std::future<reply> strlen(const std::string& key);
 
-			client &sunion(const std::vector<std::string> &keys, const reply_callback_t &reply_callback);
+  client& sunion(const std::vector<std::string>& keys, const reply_callback_t& reply_callback);
 
-			std::future<reply> sunion(const std::vector<std::string> &keys);
+  std::future<reply> sunion(const std::vector<std::string>& keys);
 
-			client &sunionstore(const std::string &destination, const std::vector<std::string> &keys,
-			                    const reply_callback_t &reply_callback);
+  client& sunionstore(const std::string& destination, const std::vector<std::string>& keys,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> sunionstore(const std::string &dst, const std::vector<std::string> &keys);
+  std::future<reply> sunionstore(const std::string& dst, const std::vector<std::string>& keys);
 
-			client &sync(const reply_callback_t &reply_callback);
+  client& sync(const reply_callback_t& reply_callback);
 
-			std::future<reply> sync();
+  std::future<reply> sync();
 
-			client &time(const reply_callback_t &reply_callback);
+  client& time(const reply_callback_t& reply_callback);
 
-			std::future<reply> time();
+  std::future<reply> time();
 
-			client &ttl(const std::string &key, const reply_callback_t &reply_callback);
+  client& ttl(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> ttl(const std::string &key);
+  std::future<reply> ttl(const std::string& key);
 
-			client &type(const std::string &key, const reply_callback_t &reply_callback);
+  client& type(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> type(const std::string &key);
+  std::future<reply> type(const std::string& key);
 
-			client &unwatch(const reply_callback_t &reply_callback);
+  client& unwatch(const reply_callback_t& reply_callback);
 
-			std::future<reply> unwatch();
+  std::future<reply> unwatch();
 
-			client &wait(int numslaves, int timeout, const reply_callback_t &reply_callback);
+  client& wait(int numslaves, int timeout, const reply_callback_t& reply_callback);
 
-			std::future<reply> wait(int numslaves, int timeout);
+  std::future<reply> wait(int numslaves, int timeout);
 
-			client &watch(const std::vector<std::string> &keys, const reply_callback_t &reply_callback);
+  client& watch(const std::vector<std::string>& keys, const reply_callback_t& reply_callback);
 
-			std::future<reply> watch(const std::vector<std::string> &keys);
+  std::future<reply> watch(const std::vector<std::string>& keys);
 
-			/**
+  /**
 			 * @brief
 			 * @param stream
 			 * @param group
@@ -1529,21 +1529,21 @@ namespace cpp_redis {
 			 * @param reply_callback
 			 * @return
 			 */
-			client &
-			xack(const std::string &stream, const std::string &group, const std::vector<std::string> &message_ids,
-			             const reply_callback_t &reply_callback);
+  client&
+  xack(const std::string& stream, const std::string& group, const std::vector<std::string>& message_ids,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			xack(const std::string &key, const std::string &group, const std::vector<std::string> &id_members);
+  std::future<reply>
+  xack(const std::string& key, const std::string& group, const std::vector<std::string>& id_members);
 
-			client &
-			xadd(const std::string &key, const std::string &id, const std::multimap<std::string, std::string> &field_members,
-			     const reply_callback_t &reply_callback);
+  client&
+  xadd(const std::string& key, const std::string& id, const std::multimap<std::string, std::string>& field_members,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			xadd(const std::string &key, const std::string &id, const std::multimap<std::string, std::string> &field_members);
+  std::future<reply>
+  xadd(const std::string& key, const std::string& id, const std::multimap<std::string, std::string>& field_members);
 
-/**
+  /**
  * @brief changes the ownership of a pending message to the specified consumer
  * @param stream
  * @param group
@@ -1554,89 +1554,89 @@ namespace cpp_redis {
  * @return
  *
  */
-			client &xclaim(const std::string &stream, const std::string &group,
-			               const std::string &consumer, int min_idle_time,
-			               const std::vector<std::string> &message_ids, const xclaim_options_t &options,
-			               const reply_callback_t &reply_callback);
+  client& xclaim(const std::string& stream, const std::string& group,
+    const std::string& consumer, int min_idle_time,
+    const std::vector<std::string>& message_ids, const xclaim_options_t& options,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			xclaim(const std::string &key, const std::string &group, const std::string &consumer, const int &min_idle_time,
-			       const std::vector<std::string> &id_members, const xclaim_options_t &options);
+  std::future<reply>
+  xclaim(const std::string& key, const std::string& group, const std::string& consumer, const int& min_idle_time,
+    const std::vector<std::string>& id_members, const xclaim_options_t& options);
 
-			client &
-			xdel(const std::string &key, const std::vector<std::string> &id_members, const reply_callback_t &reply_callback);
+  client&
+  xdel(const std::string& key, const std::vector<std::string>& id_members, const reply_callback_t& reply_callback);
 
-			std::future<reply> xdel(const std::string &key, const std::vector<std::string> &id_members);
+  std::future<reply> xdel(const std::string& key, const std::vector<std::string>& id_members);
 
-			client &
-			xgroup_create(const std::string &key, const std::string &group_name, const reply_callback_t &reply_callback);
+  client&
+  xgroup_create(const std::string& key, const std::string& group_name, const reply_callback_t& reply_callback);
 
-			client &
-			xgroup_create(const std::string &key, const std::string &group_name, const std::string &id,
-			              const reply_callback_t &reply_callback);
+  client&
+  xgroup_create(const std::string& key, const std::string& group_name, const std::string& id,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			xgroup_create(const std::string &key, const std::string &group_name, const std::string &id = "$");
+  std::future<reply>
+  xgroup_create(const std::string& key, const std::string& group_name, const std::string& id = "$");
 
-			client &
-			xgroup_set_id(const std::string &key, const std::string &group_name, const reply_callback_t &reply_callback);
+  client&
+  xgroup_set_id(const std::string& key, const std::string& group_name, const reply_callback_t& reply_callback);
 
-			client &
-			xgroup_set_id(const std::string &key, const std::string &group_name, const std::string &id,
-			              const reply_callback_t &reply_callback);
+  client&
+  xgroup_set_id(const std::string& key, const std::string& group_name, const std::string& id,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> xgroup_set_id(const std::string &key, const std::string &group_name, const std::string &id = "$");
+  std::future<reply> xgroup_set_id(const std::string& key, const std::string& group_name, const std::string& id = "$");
 
-			client &
-			xgroup_destroy(const std::string &key, const std::string &group_name, const reply_callback_t &reply_callback);
+  client&
+  xgroup_destroy(const std::string& key, const std::string& group_name, const reply_callback_t& reply_callback);
 
-			std::future<reply> xgroup_destroy(const std::string &key, const std::string &group_name);
+  std::future<reply> xgroup_destroy(const std::string& key, const std::string& group_name);
 
-			client &
-			xgroup_del_consumer(const std::string &key, const std::string &group_name, const std::string &consumer_name,
-			                    const reply_callback_t &reply_callback);
+  client&
+  xgroup_del_consumer(const std::string& key, const std::string& group_name, const std::string& consumer_name,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> xgroup_del_consumer(const std::string &key, const std::string &group_name, const std::string &consumer_name);
+  std::future<reply> xgroup_del_consumer(const std::string& key, const std::string& group_name, const std::string& consumer_name);
 
-			/**
+  /**
 			 * @brief introspection command used in order to retrieve different information about the consumer groups
 			 * @param key stream id
 			 * @param group_name stream consumer group name
 			 * @return
 			 */
-			client &
-			xinfo_consumers(const std::string &key, const std::string &group_name, const reply_callback_t &reply_callback);
+  client&
+  xinfo_consumers(const std::string& key, const std::string& group_name, const reply_callback_t& reply_callback);
 
-			/**
+  /**
 			 * @brief \copybrief client::xinfo_consumers(key, group_name, reply_callback)
 			 * @param key stream id
 			 * @param group_name
 			 * @return
 			 */
-			std::future<reply> xinfo_consumers(const std::string &key, const std::string &group_name);
+  std::future<reply> xinfo_consumers(const std::string& key, const std::string& group_name);
 
-			/**
+  /**
 			 * @brief \copybrief client::xinfo_consumers(key, group_name, reply_callback)
 			 * @param key stream id
 			 * @param reply_callback
 			 * @return
 			 */
-			client &
-			xinfo_groups(const std::string &key, const reply_callback_t &reply_callback);
+  client&
+  xinfo_groups(const std::string& key, const reply_callback_t& reply_callback);
 
-			/**
+  /**
 			 * @brief \copybrief client::xinfo_consumers(key, group_name, reply_callback)
 			 * @param stream stream id
 			 * @return
 			 */
-			std::future<reply> xinfo_groups(const std::string &stream);
+  std::future<reply> xinfo_groups(const std::string& stream);
 
-			client &
-			xinfo_stream(const std::string &stream, const reply_callback_t &reply_callback);
+  client&
+  xinfo_stream(const std::string& stream, const reply_callback_t& reply_callback);
 
-			std::future<reply> xinfo_stream(const std::string &stream);
+  std::future<reply> xinfo_stream(const std::string& stream);
 
-			/**
+  /**
 			 * @brief Returns the number of entries inside a stream.
 			 * If the specified key does not exist the command returns zero, as if the stream was empty.
 			 * However note that unlike other Redis types, zero-length streams are possible, so you should call TYPE or EXISTS in order to check if a key exists or not.
@@ -1645,17 +1645,17 @@ namespace cpp_redis {
 			 * @param reply_callback
 			 * @return Integer reply: the number of entries of the stream at key.
 			 */
-			client &
-			xlen(const std::string &stream, const reply_callback_t &reply_callback);
+  client&
+  xlen(const std::string& stream, const reply_callback_t& reply_callback);
 
-			/**
+  /**
 			 * @copydoc client::xlen(key, reply_callback)
 			 * @param key
 			 * @return
 			 */
-			std::future<reply> xlen(const std::string &key);
+  std::future<reply> xlen(const std::string& key);
 
-			/**
+  /**
 			 * @brief inspects the list of pending messages for the stream & group
 			 * @param stream
 			 * @param group
@@ -1663,704 +1663,704 @@ namespace cpp_redis {
 			 * @param reply_callback
 			 * @return
 			 */
-			client &
-			xpending(const std::string &stream,
-			                 const std::string &group,
-			                 const xpending_options_t &options,
-			                 const reply_callback_t &reply_callback);
+  client&
+  xpending(const std::string& stream,
+    const std::string& group,
+    const xpending_options_t& options,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> xpending(const std::string &stream,
-			                            const std::string &group,
-			                            const xpending_options_t &options);
-			//endregion
+  std::future<reply> xpending(const std::string& stream,
+    const std::string& group,
+    const xpending_options_t& options);
+  //endregion
 
-			/**
+  /**
 			 * @brief
 			 * @param stream
 			 * @param options
 			 * @param reply_callback
 			 * @return
 			 */
-			client &
-			xrange(const std::string &stream, const range_options_t &options, const reply_callback_t &reply_callback);
+  client&
+  xrange(const std::string& stream, const range_options_t& options, const reply_callback_t& reply_callback);
 
-			std::future<reply> xrange(const std::string &stream,
-			                          const range_options_t &range_args);
+  std::future<reply> xrange(const std::string& stream,
+    const range_options_t& range_args);
 
-			/**
+  /**
 			 * @brief
 			 * @param a streams_t Streams std::int32_t Count std::int32_t Block;
 			 * @param reply_callback
 			 * @return
 			 */
-			client &
-			xread(const xread_options_t &a, const reply_callback_t &reply_callback);
+  client&
+  xread(const xread_options_t& a, const reply_callback_t& reply_callback);
 
-			std::future<reply> xread(const xread_options_t &a);
+  std::future<reply> xread(const xread_options_t& a);
 
-			client &
-			xreadgroup(const xreadgroup_options_t &a, const reply_callback_t &reply_callback);
+  client&
+  xreadgroup(const xreadgroup_options_t& a, const reply_callback_t& reply_callback);
 
-			std::future<reply> xreadgroup(const xreadgroup_options_t &a);
+  std::future<reply> xreadgroup(const xreadgroup_options_t& a);
 
-			client &
-			xrevrange(const std::string &key, const range_options_t &range_args, const reply_callback_t &reply_callback);
+  client&
+  xrevrange(const std::string& key, const range_options_t& range_args, const reply_callback_t& reply_callback);
 
-			std::future<reply> xrevrange(const std::string &key,
-			                             const range_options_t &range_args);
+  std::future<reply> xrevrange(const std::string& key,
+    const range_options_t& range_args);
 
-			/**
+  /**
 			 * @brief trims the stream to a given number of items, evicting older items (items with lower IDs) if needed
 			 * @param stream
 			 * @param max_len
 			 * @param reply_callback
 			 * @return
 			 */
-			client &xtrim(const std::string &stream, int max_len, const reply_callback_t &reply_callback);
+  client& xtrim(const std::string& stream, int max_len, const reply_callback_t& reply_callback);
 
-			std::future<reply> xtrim(const std::string &key, int max_len);
+  std::future<reply> xtrim(const std::string& key, int max_len);
 
-/**
+  /**
  * optimizes the xtrim command
  *
  */
-			client &xtrim_approx(const std::string &key, int max_len, const reply_callback_t &reply_callback);
+  client& xtrim_approx(const std::string& key, int max_len, const reply_callback_t& reply_callback);
 
-			std::future<reply> xtrim_approx(const std::string &key, int max_len);
+  std::future<reply> xtrim_approx(const std::string& key, int max_len);
 
-			client &zadd(const std::string &key, const std::vector<std::string> &options,
-			             const std::multimap<std::string, std::string> &score_members,
-			             const reply_callback_t &reply_callback);
+  client& zadd(const std::string& key, const std::vector<std::string>& options,
+    const std::multimap<std::string, std::string>& score_members,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zadd(const std::string &key, const std::vector<std::string> &options,
-			                        const std::multimap<std::string, std::string> &score_members);
+  std::future<reply> zadd(const std::string& key, const std::vector<std::string>& options,
+    const std::multimap<std::string, std::string>& score_members);
 
-			client &zcard(const std::string &key, const reply_callback_t &reply_callback);
+  client& zcard(const std::string& key, const reply_callback_t& reply_callback);
 
-			std::future<reply> zcard(const std::string &key);
+  std::future<reply> zcard(const std::string& key);
 
-			client &zcount(const std::string &key, int min, int max, const reply_callback_t &reply_callback);
+  client& zcount(const std::string& key, int min, int max, const reply_callback_t& reply_callback);
 
-			std::future<reply> zcount(const std::string &key, int min, int max);
+  std::future<reply> zcount(const std::string& key, int min, int max);
 
-			client &zcount(const std::string &key, double min, double max, const reply_callback_t &reply_callback);
+  client& zcount(const std::string& key, double min, double max, const reply_callback_t& reply_callback);
 
-			std::future<reply> zcount(const std::string &key, double min, double max);
+  std::future<reply> zcount(const std::string& key, double min, double max);
 
-			client &zcount(const std::string &key, const std::string &min, const std::string &max,
-			               const reply_callback_t &reply_callback);
+  client& zcount(const std::string& key, const std::string& min, const std::string& max,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zcount(const std::string &key, const std::string &min, const std::string &max);
+  std::future<reply> zcount(const std::string& key, const std::string& min, const std::string& max);
 
-			client &
-			zincrby(const std::string &key, int incr, const std::string &member, const reply_callback_t &reply_callback);
+  client&
+  zincrby(const std::string& key, int incr, const std::string& member, const reply_callback_t& reply_callback);
 
-			std::future<reply> zincrby(const std::string &key, int incr, const std::string &member);
+  std::future<reply> zincrby(const std::string& key, int incr, const std::string& member);
 
-			client &
-			zincrby(const std::string &key, double incr, const std::string &member, const reply_callback_t &reply_callback);
+  client&
+  zincrby(const std::string& key, double incr, const std::string& member, const reply_callback_t& reply_callback);
 
-			std::future<reply> zincrby(const std::string &key, double incr, const std::string &member);
+  std::future<reply> zincrby(const std::string& key, double incr, const std::string& member);
 
-			client &zincrby(const std::string &key, const std::string &incr, const std::string &member,
-			                const reply_callback_t &reply_callback);
+  client& zincrby(const std::string& key, const std::string& incr, const std::string& member,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zincrby(const std::string &key, const std::string &incr, const std::string &member);
+  std::future<reply> zincrby(const std::string& key, const std::string& incr, const std::string& member);
 
-			client &zinterstore(const std::string &destination, std::size_t numkeys, const std::vector<std::string> &keys,
-			                    std::vector<std::size_t> weights, aggregate_method method,
-			                    const reply_callback_t &reply_callback);
+  client& zinterstore(const std::string& destination, std::size_t numkeys, const std::vector<std::string>& keys,
+    std::vector<std::size_t> weights, aggregate_method method,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zinterstore(const std::string &destination, std::size_t numkeys, const std::vector<std::string> &keys,
-			            std::vector<std::size_t> weights, aggregate_method method);
+  std::future<reply>
+  zinterstore(const std::string& destination, std::size_t numkeys, const std::vector<std::string>& keys,
+    std::vector<std::size_t> weights, aggregate_method method);
 
-			client &zlexcount(const std::string &key, int min, int max, const reply_callback_t &reply_callback);
+  client& zlexcount(const std::string& key, int min, int max, const reply_callback_t& reply_callback);
 
-			std::future<reply> zlexcount(const std::string &key, int min, int max);
+  std::future<reply> zlexcount(const std::string& key, int min, int max);
 
-			client &zlexcount(const std::string &key, double min, double max, const reply_callback_t &reply_callback);
+  client& zlexcount(const std::string& key, double min, double max, const reply_callback_t& reply_callback);
 
-			std::future<reply> zlexcount(const std::string &key, double min, double max);
+  std::future<reply> zlexcount(const std::string& key, double min, double max);
 
-			client &zlexcount(const std::string &key, const std::string &min, const std::string &max,
-			                  const reply_callback_t &reply_callback);
+  client& zlexcount(const std::string& key, const std::string& min, const std::string& max,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zlexcount(const std::string &key, const std::string &min, const std::string &max);
+  std::future<reply> zlexcount(const std::string& key, const std::string& min, const std::string& max);
 
-  			client& zpopmin(const std::string& key, int count, const reply_callback_t& reply_callback);
+  client& zpopmin(const std::string& key, int count, const reply_callback_t& reply_callback);
 
-			std::future<reply> zpopmin(const std::string& key, int count);
+  std::future<reply> zpopmin(const std::string& key, int count);
 
-			client& zpopmax(const std::string& key, int count, const reply_callback_t& reply_callback);
+  client& zpopmax(const std::string& key, int count, const reply_callback_t& reply_callback);
 
-  			std::future<reply> zpopmax(const std::string& key, int count);
+  std::future<reply> zpopmax(const std::string& key, int count);
 
-			client &zrange(const std::string &key, int start, int stop, const reply_callback_t &reply_callback);
+  client& zrange(const std::string& key, int start, int stop, const reply_callback_t& reply_callback);
 
-			client &
-			zrange(const std::string &key, int start, int stop, bool withscores, const reply_callback_t &reply_callback);
+  client&
+  zrange(const std::string& key, int start, int stop, bool withscores, const reply_callback_t& reply_callback);
 
-			std::future<reply> zrange(const std::string &key, int start, int stop, bool withscores = false);
+  std::future<reply> zrange(const std::string& key, int start, int stop, bool withscores = false);
 
-			client &zrange(const std::string &key, double start, double stop, const reply_callback_t &reply_callback);
+  client& zrange(const std::string& key, double start, double stop, const reply_callback_t& reply_callback);
 
-			client &zrange(const std::string &key, double start, double stop, bool withscores,
-			               const reply_callback_t &reply_callback);
+  client& zrange(const std::string& key, double start, double stop, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zrange(const std::string &key, double start, double stop, bool withscores = false);
+  std::future<reply> zrange(const std::string& key, double start, double stop, bool withscores = false);
 
-			client &zrange(const std::string &key, const std::string &start, const std::string &stop,
-			               const reply_callback_t &reply_callback);
+  client& zrange(const std::string& key, const std::string& start, const std::string& stop,
+    const reply_callback_t& reply_callback);
 
-			client &zrange(const std::string &key, const std::string &start, const std::string &stop, bool withscores,
-			               const reply_callback_t &reply_callback);
+  client& zrange(const std::string& key, const std::string& start, const std::string& stop, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrange(const std::string &key, const std::string &start, const std::string &stop, bool withscores = false);
+  std::future<reply>
+  zrange(const std::string& key, const std::string& start, const std::string& stop, bool withscores = false);
 
-			client &zrangebylex(const std::string &key, int min, int max, const reply_callback_t &reply_callback);
+  client& zrangebylex(const std::string& key, int min, int max, const reply_callback_t& reply_callback);
 
-			client &
-			zrangebylex(const std::string &key, int min, int max, bool withscores, const reply_callback_t &reply_callback);
+  client&
+  zrangebylex(const std::string& key, int min, int max, bool withscores, const reply_callback_t& reply_callback);
 
-			std::future<reply> zrangebylex(const std::string &key, int min, int max, bool withscores = false);
+  std::future<reply> zrangebylex(const std::string& key, int min, int max, bool withscores = false);
 
-			client &zrangebylex(const std::string &key, double min, double max, const reply_callback_t &reply_callback);
+  client& zrangebylex(const std::string& key, double min, double max, const reply_callback_t& reply_callback);
 
-			client &zrangebylex(const std::string &key, double min, double max, bool withscores,
-			                    const reply_callback_t &reply_callback);
+  client& zrangebylex(const std::string& key, double min, double max, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zrangebylex(const std::string &key, double min, double max, bool withscores = false);
+  std::future<reply> zrangebylex(const std::string& key, double min, double max, bool withscores = false);
 
-			client &zrangebylex(const std::string &key, const std::string &min, const std::string &max,
-			                    const reply_callback_t &reply_callback);
+  client& zrangebylex(const std::string& key, const std::string& min, const std::string& max,
+    const reply_callback_t& reply_callback);
 
-			client &zrangebylex(const std::string &key, const std::string &min, const std::string &max, bool withscores,
-			                    const reply_callback_t &reply_callback);
+  client& zrangebylex(const std::string& key, const std::string& min, const std::string& max, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrangebylex(const std::string &key, const std::string &min, const std::string &max, bool withscores = false);
+  std::future<reply>
+  zrangebylex(const std::string& key, const std::string& min, const std::string& max, bool withscores = false);
 
-			client &zrangebylex(const std::string &key, int min, int max, std::size_t offset, std::size_t count,
-			                    const reply_callback_t &reply_callback);
+  client& zrangebylex(const std::string& key, int min, int max, std::size_t offset, std::size_t count,
+    const reply_callback_t& reply_callback);
 
-			client &
-			zrangebylex(const std::string &key, int min, int max, std::size_t offset, std::size_t count, bool withscores,
-			            const reply_callback_t &reply_callback);
+  client&
+  zrangebylex(const std::string& key, int min, int max, std::size_t offset, std::size_t count, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zrangebylex(const std::string &key, int min, int max, std::size_t offset, std::size_t count,
-			                               bool withscores = false);
+  std::future<reply> zrangebylex(const std::string& key, int min, int max, std::size_t offset, std::size_t count,
+    bool withscores = false);
 
-			client &zrangebylex(const std::string &key, double min, double max, std::size_t offset, std::size_t count,
-			                    const reply_callback_t &reply_callback);
+  client& zrangebylex(const std::string& key, double min, double max, std::size_t offset, std::size_t count,
+    const reply_callback_t& reply_callback);
 
-			client &zrangebylex(const std::string &key, double min, double max, std::size_t offset, std::size_t count,
-			                    bool withscores, const reply_callback_t &reply_callback);
+  client& zrangebylex(const std::string& key, double min, double max, std::size_t offset, std::size_t count,
+    bool withscores, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrangebylex(const std::string &key, double min, double max, std::size_t offset, std::size_t count,
-			            bool withscores = false);
+  std::future<reply>
+  zrangebylex(const std::string& key, double min, double max, std::size_t offset, std::size_t count,
+    bool withscores = false);
 
-			client &zrangebylex(const std::string &key, const std::string &min, const std::string &max, std::size_t offset,
-			                    std::size_t count, const reply_callback_t &reply_callback);
+  client& zrangebylex(const std::string& key, const std::string& min, const std::string& max, std::size_t offset,
+    std::size_t count, const reply_callback_t& reply_callback);
 
-			client &zrangebylex(const std::string &key, const std::string &min, const std::string &max, std::size_t offset,
-			                    std::size_t count, bool withscores, const reply_callback_t &reply_callback);
+  client& zrangebylex(const std::string& key, const std::string& min, const std::string& max, std::size_t offset,
+    std::size_t count, bool withscores, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrangebylex(const std::string &key, const std::string &min, const std::string &max, std::size_t offset,
-			            std::size_t count, bool withscores = false);
+  std::future<reply>
+  zrangebylex(const std::string& key, const std::string& min, const std::string& max, std::size_t offset,
+    std::size_t count, bool withscores = false);
 
-			client &zrangebyscore(const std::string &key, int min, int max, const reply_callback_t &reply_callback);
+  client& zrangebyscore(const std::string& key, int min, int max, const reply_callback_t& reply_callback);
 
-			client &
-			zrangebyscore(const std::string &key, int min, int max, bool withscores, const reply_callback_t &reply_callback);
+  client&
+  zrangebyscore(const std::string& key, int min, int max, bool withscores, const reply_callback_t& reply_callback);
 
-			std::future<reply> zrangebyscore(const std::string &key, int min, int max, bool withscores = false);
+  std::future<reply> zrangebyscore(const std::string& key, int min, int max, bool withscores = false);
 
-			client &zrangebyscore(const std::string &key, double min, double max, const reply_callback_t &reply_callback);
+  client& zrangebyscore(const std::string& key, double min, double max, const reply_callback_t& reply_callback);
 
-			client &zrangebyscore(const std::string &key, double min, double max, bool withscores,
-			                      const reply_callback_t &reply_callback);
+  client& zrangebyscore(const std::string& key, double min, double max, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zrangebyscore(const std::string &key, double min, double max, bool withscores = false);
+  std::future<reply> zrangebyscore(const std::string& key, double min, double max, bool withscores = false);
 
-			client &zrangebyscore(const std::string &key, const std::string &min, const std::string &max,
-			                      const reply_callback_t &reply_callback);
+  client& zrangebyscore(const std::string& key, const std::string& min, const std::string& max,
+    const reply_callback_t& reply_callback);
 
-			client &zrangebyscore(const std::string &key, const std::string &min, const std::string &max, bool withscores,
-			                      const reply_callback_t &reply_callback);
+  client& zrangebyscore(const std::string& key, const std::string& min, const std::string& max, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrangebyscore(const std::string &key, const std::string &min, const std::string &max, bool withscores = false);
+  std::future<reply>
+  zrangebyscore(const std::string& key, const std::string& min, const std::string& max, bool withscores = false);
 
-			client &zrangebyscore(const std::string &key, int min, int max, std::size_t offset, std::size_t count,
-			                      const reply_callback_t &reply_callback);
+  client& zrangebyscore(const std::string& key, int min, int max, std::size_t offset, std::size_t count,
+    const reply_callback_t& reply_callback);
 
-			client &
-			zrangebyscore(const std::string &key, int min, int max, std::size_t offset, std::size_t count, bool withscores,
-			              const reply_callback_t &reply_callback);
+  client&
+  zrangebyscore(const std::string& key, int min, int max, std::size_t offset, std::size_t count, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zrangebyscore(const std::string &key, int min, int max, std::size_t offset, std::size_t count,
-			                                 bool withscores = false);
+  std::future<reply> zrangebyscore(const std::string& key, int min, int max, std::size_t offset, std::size_t count,
+    bool withscores = false);
 
-			client &zrangebyscore(const std::string &key, double min, double max, std::size_t offset, std::size_t count,
-			                      const reply_callback_t &reply_callback);
+  client& zrangebyscore(const std::string& key, double min, double max, std::size_t offset, std::size_t count,
+    const reply_callback_t& reply_callback);
 
-			client &zrangebyscore(const std::string &key, double min, double max, std::size_t offset, std::size_t count,
-			                      bool withscores, const reply_callback_t &reply_callback);
+  client& zrangebyscore(const std::string& key, double min, double max, std::size_t offset, std::size_t count,
+    bool withscores, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrangebyscore(const std::string &key, double min, double max, std::size_t offset, std::size_t count,
-			              bool withscores = false);
+  std::future<reply>
+  zrangebyscore(const std::string& key, double min, double max, std::size_t offset, std::size_t count,
+    bool withscores = false);
 
-			client &zrangebyscore(const std::string &key, const std::string &min, const std::string &max, std::size_t offset,
-			                      std::size_t count, const reply_callback_t &reply_callback);
+  client& zrangebyscore(const std::string& key, const std::string& min, const std::string& max, std::size_t offset,
+    std::size_t count, const reply_callback_t& reply_callback);
 
-			client &zrangebyscore(const std::string &key, const std::string &min, const std::string &max, std::size_t offset,
-			                      std::size_t count, bool withscores, const reply_callback_t &reply_callback);
+  client& zrangebyscore(const std::string& key, const std::string& min, const std::string& max, std::size_t offset,
+    std::size_t count, bool withscores, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrangebyscore(const std::string &key, const std::string &min, const std::string &max, std::size_t offset,
-			              std::size_t count, bool withscores = false);
+  std::future<reply>
+  zrangebyscore(const std::string& key, const std::string& min, const std::string& max, std::size_t offset,
+    std::size_t count, bool withscores = false);
 
-			client &zrank(const std::string &key, const std::string &member, const reply_callback_t &reply_callback);
+  client& zrank(const std::string& key, const std::string& member, const reply_callback_t& reply_callback);
 
-			std::future<reply> zrank(const std::string &key, const std::string &member);
+  std::future<reply> zrank(const std::string& key, const std::string& member);
 
-			client &
-			zrem(const std::string &key, const std::vector<std::string> &members, const reply_callback_t &reply_callback);
+  client&
+  zrem(const std::string& key, const std::vector<std::string>& members, const reply_callback_t& reply_callback);
 
-			std::future<reply> zrem(const std::string &key, const std::vector<std::string> &members);
+  std::future<reply> zrem(const std::string& key, const std::vector<std::string>& members);
 
-			client &zremrangebylex(const std::string &key, int min, int max, const reply_callback_t &reply_callback);
+  client& zremrangebylex(const std::string& key, int min, int max, const reply_callback_t& reply_callback);
 
-			std::future<reply> zremrangebylex(const std::string &key, int min, int max);
+  std::future<reply> zremrangebylex(const std::string& key, int min, int max);
 
-			client &zremrangebylex(const std::string &key, double min, double max, const reply_callback_t &reply_callback);
+  client& zremrangebylex(const std::string& key, double min, double max, const reply_callback_t& reply_callback);
 
-			std::future<reply> zremrangebylex(const std::string &key, double min, double max);
+  std::future<reply> zremrangebylex(const std::string& key, double min, double max);
 
-			client &zremrangebylex(const std::string &key, const std::string &min, const std::string &max,
-			                       const reply_callback_t &reply_callback);
+  client& zremrangebylex(const std::string& key, const std::string& min, const std::string& max,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zremrangebylex(const std::string &key, const std::string &min, const std::string &max);
+  std::future<reply> zremrangebylex(const std::string& key, const std::string& min, const std::string& max);
 
-			client &zremrangebyrank(const std::string &key, int start, int stop, const reply_callback_t &reply_callback);
+  client& zremrangebyrank(const std::string& key, int start, int stop, const reply_callback_t& reply_callback);
 
-			std::future<reply> zremrangebyrank(const std::string &key, int start, int stop);
+  std::future<reply> zremrangebyrank(const std::string& key, int start, int stop);
 
-			client &
-			zremrangebyrank(const std::string &key, double start, double stop, const reply_callback_t &reply_callback);
+  client&
+  zremrangebyrank(const std::string& key, double start, double stop, const reply_callback_t& reply_callback);
 
-			std::future<reply> zremrangebyrank(const std::string &key, double start, double stop);
+  std::future<reply> zremrangebyrank(const std::string& key, double start, double stop);
 
-			client &zremrangebyrank(const std::string &key, const std::string &start, const std::string &stop,
-			                        const reply_callback_t &reply_callback);
+  client& zremrangebyrank(const std::string& key, const std::string& start, const std::string& stop,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zremrangebyrank(const std::string &key, const std::string &start, const std::string &stop);
+  std::future<reply> zremrangebyrank(const std::string& key, const std::string& start, const std::string& stop);
 
-			client &zremrangebyscore(const std::string &key, int min, int max, const reply_callback_t &reply_callback);
+  client& zremrangebyscore(const std::string& key, int min, int max, const reply_callback_t& reply_callback);
 
-			std::future<reply> zremrangebyscore(const std::string &key, int min, int max);
+  std::future<reply> zremrangebyscore(const std::string& key, int min, int max);
 
-			client &zremrangebyscore(const std::string &key, double min, double max, const reply_callback_t &reply_callback);
+  client& zremrangebyscore(const std::string& key, double min, double max, const reply_callback_t& reply_callback);
 
-			std::future<reply> zremrangebyscore(const std::string &key, double min, double max);
+  std::future<reply> zremrangebyscore(const std::string& key, double min, double max);
 
-			client &zremrangebyscore(const std::string &key, const std::string &min, const std::string &max,
-			                         const reply_callback_t &reply_callback);
+  client& zremrangebyscore(const std::string& key, const std::string& min, const std::string& max,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zremrangebyscore(const std::string &key, const std::string &min, const std::string &max);
+  std::future<reply> zremrangebyscore(const std::string& key, const std::string& min, const std::string& max);
 
-			client &zrevrange(const std::string &key, int start, int stop, const reply_callback_t &reply_callback);
+  client& zrevrange(const std::string& key, int start, int stop, const reply_callback_t& reply_callback);
 
-			client &
-			zrevrange(const std::string &key, int start, int stop, bool withscores, const reply_callback_t &reply_callback);
+  client&
+  zrevrange(const std::string& key, int start, int stop, bool withscores, const reply_callback_t& reply_callback);
 
-			std::future<reply> zrevrange(const std::string &key, int start, int stop, bool withscores = false);
+  std::future<reply> zrevrange(const std::string& key, int start, int stop, bool withscores = false);
 
-			client &zrevrange(const std::string &key, double start, double stop, const reply_callback_t &reply_callback);
+  client& zrevrange(const std::string& key, double start, double stop, const reply_callback_t& reply_callback);
 
-			client &zrevrange(const std::string &key, double start, double stop, bool withscores,
-			                  const reply_callback_t &reply_callback);
+  client& zrevrange(const std::string& key, double start, double stop, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zrevrange(const std::string &key, double start, double stop, bool withscores = false);
+  std::future<reply> zrevrange(const std::string& key, double start, double stop, bool withscores = false);
 
-			client &zrevrange(const std::string &key, const std::string &start, const std::string &stop,
-			                  const reply_callback_t &reply_callback);
+  client& zrevrange(const std::string& key, const std::string& start, const std::string& stop,
+    const reply_callback_t& reply_callback);
 
-			client &zrevrange(const std::string &key, const std::string &start, const std::string &stop, bool withscores,
-			                  const reply_callback_t &reply_callback);
+  client& zrevrange(const std::string& key, const std::string& start, const std::string& stop, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrevrange(const std::string &key, const std::string &start, const std::string &stop, bool withscores = false);
+  std::future<reply>
+  zrevrange(const std::string& key, const std::string& start, const std::string& stop, bool withscores = false);
 
-			client &zrevrangebylex(const std::string &key, int max, int min, const reply_callback_t &reply_callback);
+  client& zrevrangebylex(const std::string& key, int max, int min, const reply_callback_t& reply_callback);
 
-			client &
-			zrevrangebylex(const std::string &key, int max, int min, bool withscores, const reply_callback_t &reply_callback);
+  client&
+  zrevrangebylex(const std::string& key, int max, int min, bool withscores, const reply_callback_t& reply_callback);
 
-			std::future<reply> zrevrangebylex(const std::string &key, int max, int min, bool withscores = false);
+  std::future<reply> zrevrangebylex(const std::string& key, int max, int min, bool withscores = false);
 
-			client &zrevrangebylex(const std::string &key, double max, double min, const reply_callback_t &reply_callback);
+  client& zrevrangebylex(const std::string& key, double max, double min, const reply_callback_t& reply_callback);
 
-			client &zrevrangebylex(const std::string &key, double max, double min, bool withscores,
-			                       const reply_callback_t &reply_callback);
+  client& zrevrangebylex(const std::string& key, double max, double min, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zrevrangebylex(const std::string &key, double max, double min, bool withscores = false);
+  std::future<reply> zrevrangebylex(const std::string& key, double max, double min, bool withscores = false);
 
-			client &zrevrangebylex(const std::string &key, const std::string &max, const std::string &min,
-			                       const reply_callback_t &reply_callback);
+  client& zrevrangebylex(const std::string& key, const std::string& max, const std::string& min,
+    const reply_callback_t& reply_callback);
 
-			client &zrevrangebylex(const std::string &key, const std::string &max, const std::string &min, bool withscores,
-			                       const reply_callback_t &reply_callback);
+  client& zrevrangebylex(const std::string& key, const std::string& max, const std::string& min, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrevrangebylex(const std::string &key, const std::string &max, const std::string &min, bool withscores = false);
+  std::future<reply>
+  zrevrangebylex(const std::string& key, const std::string& max, const std::string& min, bool withscores = false);
 
-			client &zrevrangebylex(const std::string &key, int max, int min, std::size_t offset, std::size_t count,
-			                       const reply_callback_t &reply_callback);
+  client& zrevrangebylex(const std::string& key, int max, int min, std::size_t offset, std::size_t count,
+    const reply_callback_t& reply_callback);
 
-			client &
-			zrevrangebylex(const std::string &key, int max, int min, std::size_t offset, std::size_t count, bool withscores,
-			               const reply_callback_t &reply_callback);
+  client&
+  zrevrangebylex(const std::string& key, int max, int min, std::size_t offset, std::size_t count, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zrevrangebylex(const std::string &key, int max, int min, std::size_t offset, std::size_t count,
-			                                  bool withscores = false);
+  std::future<reply> zrevrangebylex(const std::string& key, int max, int min, std::size_t offset, std::size_t count,
+    bool withscores = false);
 
-			client &zrevrangebylex(const std::string &key, double max, double min, std::size_t offset, std::size_t count,
-			                       const reply_callback_t &reply_callback);
+  client& zrevrangebylex(const std::string& key, double max, double min, std::size_t offset, std::size_t count,
+    const reply_callback_t& reply_callback);
 
-			client &zrevrangebylex(const std::string &key, double max, double min, std::size_t offset, std::size_t count,
-			                       bool withscores, const reply_callback_t &reply_callback);
+  client& zrevrangebylex(const std::string& key, double max, double min, std::size_t offset, std::size_t count,
+    bool withscores, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrevrangebylex(const std::string &key, double max, double min, std::size_t offset, std::size_t count,
-			               bool withscores = false);
+  std::future<reply>
+  zrevrangebylex(const std::string& key, double max, double min, std::size_t offset, std::size_t count,
+    bool withscores = false);
 
-			client &zrevrangebylex(const std::string &key, const std::string &max, const std::string &min, std::size_t offset,
-			                       std::size_t count, const reply_callback_t &reply_callback);
+  client& zrevrangebylex(const std::string& key, const std::string& max, const std::string& min, std::size_t offset,
+    std::size_t count, const reply_callback_t& reply_callback);
 
-			client &zrevrangebylex(const std::string &key, const std::string &max, const std::string &min, std::size_t offset,
-			                       std::size_t count, bool withscores, const reply_callback_t &reply_callback);
+  client& zrevrangebylex(const std::string& key, const std::string& max, const std::string& min, std::size_t offset,
+    std::size_t count, bool withscores, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrevrangebylex(const std::string &key, const std::string &max, const std::string &min, std::size_t offset,
-			               std::size_t count, bool withscores = false);
+  std::future<reply>
+  zrevrangebylex(const std::string& key, const std::string& max, const std::string& min, std::size_t offset,
+    std::size_t count, bool withscores = false);
 
-			client &zrevrangebyscore(const std::string &key, int max, int min, const reply_callback_t &reply_callback);
+  client& zrevrangebyscore(const std::string& key, int max, int min, const reply_callback_t& reply_callback);
 
-			client &zrevrangebyscore(const std::string &key, int max, int min, bool withscores,
-			                         const reply_callback_t &reply_callback);
+  client& zrevrangebyscore(const std::string& key, int max, int min, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zrevrangebyscore(const std::string &key, int max, int min, bool withscores = false);
+  std::future<reply> zrevrangebyscore(const std::string& key, int max, int min, bool withscores = false);
 
-			client &zrevrangebyscore(const std::string &key, double max, double min, const reply_callback_t &reply_callback);
+  client& zrevrangebyscore(const std::string& key, double max, double min, const reply_callback_t& reply_callback);
 
-			client &zrevrangebyscore(const std::string &key, double max, double min, bool withscores,
-			                         const reply_callback_t &reply_callback);
+  client& zrevrangebyscore(const std::string& key, double max, double min, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zrevrangebyscore(const std::string &key, double max, double min, bool withscores = false);
+  std::future<reply> zrevrangebyscore(const std::string& key, double max, double min, bool withscores = false);
 
-			client &zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min,
-			                         const reply_callback_t &reply_callback);
+  client& zrevrangebyscore(const std::string& key, const std::string& max, const std::string& min,
+    const reply_callback_t& reply_callback);
 
-			client &zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min, bool withscores,
-			                         const reply_callback_t &reply_callback);
+  client& zrevrangebyscore(const std::string& key, const std::string& max, const std::string& min, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min, bool withscores = false);
+  std::future<reply>
+  zrevrangebyscore(const std::string& key, const std::string& max, const std::string& min, bool withscores = false);
 
-			client &zrevrangebyscore(const std::string &key, int max, int min, std::size_t offset, std::size_t count,
-			                         const reply_callback_t &reply_callback);
+  client& zrevrangebyscore(const std::string& key, int max, int min, std::size_t offset, std::size_t count,
+    const reply_callback_t& reply_callback);
 
-			client &
-			zrevrangebyscore(const std::string &key, int max, int min, std::size_t offset, std::size_t count, bool withscores,
-			                 const reply_callback_t &reply_callback);
+  client&
+  zrevrangebyscore(const std::string& key, int max, int min, std::size_t offset, std::size_t count, bool withscores,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrevrangebyscore(const std::string &key, int max, int min, std::size_t offset, std::size_t count,
-			                 bool withscores = false);
+  std::future<reply>
+  zrevrangebyscore(const std::string& key, int max, int min, std::size_t offset, std::size_t count,
+    bool withscores = false);
 
-			client &zrevrangebyscore(const std::string &key, double max, double min, std::size_t offset, std::size_t count,
-			                         const reply_callback_t &reply_callback);
+  client& zrevrangebyscore(const std::string& key, double max, double min, std::size_t offset, std::size_t count,
+    const reply_callback_t& reply_callback);
 
-			client &zrevrangebyscore(const std::string &key, double max, double min, std::size_t offset, std::size_t count,
-			                         bool withscores, const reply_callback_t &reply_callback);
+  client& zrevrangebyscore(const std::string& key, double max, double min, std::size_t offset, std::size_t count,
+    bool withscores, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrevrangebyscore(const std::string &key, double max, double min, std::size_t offset, std::size_t count,
-			                 bool withscores = false);
+  std::future<reply>
+  zrevrangebyscore(const std::string& key, double max, double min, std::size_t offset, std::size_t count,
+    bool withscores = false);
 
-			client &
-			zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min, std::size_t offset,
-			                 std::size_t count, const reply_callback_t &reply_callback);
+  client&
+  zrevrangebyscore(const std::string& key, const std::string& max, const std::string& min, std::size_t offset,
+    std::size_t count, const reply_callback_t& reply_callback);
 
-			client &
-			zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min, std::size_t offset,
-			                 std::size_t count, bool withscores, const reply_callback_t &reply_callback);
+  client&
+  zrevrangebyscore(const std::string& key, const std::string& max, const std::string& min, std::size_t offset,
+    std::size_t count, bool withscores, const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min, std::size_t offset,
-			                 std::size_t count, bool withscores = false);
+  std::future<reply>
+  zrevrangebyscore(const std::string& key, const std::string& max, const std::string& min, std::size_t offset,
+    std::size_t count, bool withscores = false);
 
-			client &zrevrank(const std::string &key, const std::string &member, const reply_callback_t &reply_callback);
+  client& zrevrank(const std::string& key, const std::string& member, const reply_callback_t& reply_callback);
 
-			std::future<reply> zrevrank(const std::string &key, const std::string &member);
+  std::future<reply> zrevrank(const std::string& key, const std::string& member);
 
-			client &zscan(const std::string &key, std::size_t cursor, const reply_callback_t &reply_callback);
+  client& zscan(const std::string& key, std::size_t cursor, const reply_callback_t& reply_callback);
 
-			std::future<reply> zscan(const std::string &key, std::size_t cursor);
+  std::future<reply> zscan(const std::string& key, std::size_t cursor);
 
-			client &zscan(const std::string &key, std::size_t cursor, const std::string &pattern,
-			              const reply_callback_t &reply_callback);
+  client& zscan(const std::string& key, std::size_t cursor, const std::string& pattern,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply> zscan(const std::string &key, std::size_t cursor, const std::string &pattern);
+  std::future<reply> zscan(const std::string& key, std::size_t cursor, const std::string& pattern);
 
-			client &
-			zscan(const std::string &key, std::size_t cursor, std::size_t count, const reply_callback_t &reply_callback);
+  client&
+  zscan(const std::string& key, std::size_t cursor, std::size_t count, const reply_callback_t& reply_callback);
 
-			std::future<reply> zscan(const std::string &key, std::size_t cursor, std::size_t count);
+  std::future<reply> zscan(const std::string& key, std::size_t cursor, std::size_t count);
 
-			client &zscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count,
-			              const reply_callback_t &reply_callback);
+  client& zscan(const std::string& key, std::size_t cursor, const std::string& pattern, std::size_t count,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count);
+  std::future<reply>
+  zscan(const std::string& key, std::size_t cursor, const std::string& pattern, std::size_t count);
 
-			client &zscore(const std::string &key, const std::string &member, const reply_callback_t &reply_callback);
+  client& zscore(const std::string& key, const std::string& member, const reply_callback_t& reply_callback);
 
-			std::future<reply> zscore(const std::string &key, const std::string &member);
+  std::future<reply> zscore(const std::string& key, const std::string& member);
 
-			client &zunionstore(const std::string &destination, std::size_t numkeys, const std::vector<std::string> &keys,
-			                    std::vector<std::size_t> weights, aggregate_method method,
-			                    const reply_callback_t &reply_callback);
+  client& zunionstore(const std::string& destination, std::size_t numkeys, const std::vector<std::string>& keys,
+    std::vector<std::size_t> weights, aggregate_method method,
+    const reply_callback_t& reply_callback);
 
-			std::future<reply>
-			zunionstore(const std::string &destination, std::size_t numkeys, const std::vector<std::string> &keys,
-			            std::vector<std::size_t> weights, aggregate_method method);
+  std::future<reply>
+  zunionstore(const std::string& destination, std::size_t numkeys, const std::vector<std::string>& keys,
+    std::vector<std::size_t> weights, aggregate_method method);
 
-	private:
-/**
+private:
+  /**
  * client kill impl
  *
  */
-			template<typename T>
-			typename std::enable_if<std::is_same<T, client_type>::value>::type
-			client_kill_unpack_arg(std::vector<std::string> &redis_cmd, reply_callback_t &, client_type type);
+  template <typename T>
+  typename std::enable_if<std::is_same<T, client_type>::value>::type
+  client_kill_unpack_arg(std::vector<std::string>& redis_cmd, reply_callback_t&, client_type type);
 
-			template<typename T>
-			typename std::enable_if<std::is_same<T, bool>::value>::type
-			client_kill_unpack_arg(std::vector<std::string> &redis_cmd, reply_callback_t &, bool skip);
+  template <typename T>
+  typename std::enable_if<std::is_same<T, bool>::value>::type
+  client_kill_unpack_arg(std::vector<std::string>& redis_cmd, reply_callback_t&, bool skip);
 
-			template<typename T>
-			typename std::enable_if<std::is_integral<T>::value>::type
-			client_kill_unpack_arg(std::vector<std::string> &redis_cmd, reply_callback_t &, uint64_t id);
+  template <typename T>
+  typename std::enable_if<std::is_integral<T>::value>::type
+  client_kill_unpack_arg(std::vector<std::string>& redis_cmd, reply_callback_t&, uint64_t id);
 
-			template<typename T>
-			typename std::enable_if<std::is_class<T>::value>::type
-			client_kill_unpack_arg(std::vector<std::string> &, reply_callback_t &reply_callback, const T &cb);
+  template <typename T>
+  typename std::enable_if<std::is_class<T>::value>::type
+  client_kill_unpack_arg(std::vector<std::string>&, reply_callback_t& reply_callback, const T& cb);
 
-			template<typename T, typename... Ts>
-			void
-			client_kill_impl(std::vector<std::string> &redis_cmd, reply_callback_t &reply, const T &arg, const Ts &... args);
+  template <typename T, typename... Ts>
+  void
+  client_kill_impl(std::vector<std::string>& redis_cmd, reply_callback_t& reply, const T& arg, const Ts&... args);
 
-			template<typename T>
-			void
-			client_kill_impl(std::vector<std::string> &redis_cmd, reply_callback_t &reply, const T &arg);
+  template <typename T>
+  void
+  client_kill_impl(std::vector<std::string>& redis_cmd, reply_callback_t& reply, const T& arg);
 
-	private:
-/**
+private:
+  /**
  * sort impl
  *
  */
-			client &
-			sort(const std::string &key, const std::string &by_pattern, bool limit, std::size_t offset, std::size_t count,
-			     const std::vector<std::string> &get_patterns, bool asc_order, bool alpha, const std::string &store_dest,
-			     const reply_callback_t &reply_callback);
+  client&
+  sort(const std::string& key, const std::string& by_pattern, bool limit, std::size_t offset, std::size_t count,
+    const std::vector<std::string>& get_patterns, bool asc_order, bool alpha, const std::string& store_dest,
+    const reply_callback_t& reply_callback);
 
-/**
+  /**
  * zrevrangebyscore impl
  *
  */
-			client &zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min, bool limit,
-			                         std::size_t offset, std::size_t count, bool withscores,
-			                         const reply_callback_t &reply_callback);
+  client& zrevrangebyscore(const std::string& key, const std::string& max, const std::string& min, bool limit,
+    std::size_t offset, std::size_t count, bool withscores,
+    const reply_callback_t& reply_callback);
 
-/**
+  /**
  * zrangebyscore impl
  *
  */
-			client &zrangebyscore(const std::string &key, const std::string &min, const std::string &max, bool limit,
-			                      std::size_t offset, std::size_t count, bool withscores,
-			                      const reply_callback_t &reply_callback);
+  client& zrangebyscore(const std::string& key, const std::string& min, const std::string& max, bool limit,
+    std::size_t offset, std::size_t count, bool withscores,
+    const reply_callback_t& reply_callback);
 
-/**
+  /**
  * zrevrangebylex impl
  *
  */
-			client &zrevrangebylex(const std::string &key, const std::string &max, const std::string &min, bool limit,
-			                       std::size_t offset, std::size_t count, bool withscores,
-			                       const reply_callback_t &reply_callback);
+  client& zrevrangebylex(const std::string& key, const std::string& max, const std::string& min, bool limit,
+    std::size_t offset, std::size_t count, bool withscores,
+    const reply_callback_t& reply_callback);
 
-/**
+  /**
  * zrangebylex impl
  *
  */
-			client &zrangebylex(const std::string &key, const std::string &min, const std::string &max, bool limit,
-			                    std::size_t offset, std::size_t count, bool withscores,
-			                    const reply_callback_t &reply_callback);
+  client& zrangebylex(const std::string& key, const std::string& min, const std::string& max, bool limit,
+    std::size_t offset, std::size_t count, bool withscores,
+    const reply_callback_t& reply_callback);
 
-	private:
-/**
+private:
+  /**
  * redis connection receive handler, triggered whenever a reply has been read by the redis connection
  *
  * @param connection redis_connection instance
  * @param reply parsed reply
  *
  */
-			void connection_receive_handler(network::redis_connection &connection, reply &reply);
+  void connection_receive_handler(network::redis_connection& connection, reply& reply);
 
-/**
+  /**
  * redis_connection disconnection handler, triggered whenever a disconnection occurred
  *
  * @param connection redis_connection instance
  *
  */
-			void connection_disconnection_handler(network::redis_connection &connection);
+  void connection_disconnection_handler(network::redis_connection& connection);
 
-/**
+  /**
  * reset the queue of pending callbacks
  *
  */
-			void clear_callbacks();
+  void clear_callbacks();
 
-/**
+  /**
  * try to commit the pending pipelined
  * if client is disconnected, will throw an exception and clear all pending callbacks (call clear_callbacks())
  *
  */
-			void try_commit();
+  void try_commit();
 
-/**
+  /**
  * Execute a command on the client and tie the callback to a future
  *
  */
-			std::future<reply> exec_cmd(const std::function<client &(const reply_callback_t &)> &f);
+  std::future<reply> exec_cmd(const std::function<client&(const reply_callback_t&)>& f);
 
-	private:
-/**
+private:
+  /**
  * struct to store commands information (command to be sent and callback to be called)
  *
  */
-			struct command_request {
-					std::vector<std::string> command;
-					reply_callback_t callback;
-			};
+  struct command_request {
+    std::vector<std::string> command;
+    reply_callback_t callback;
+  };
 
-	private:
-/**
+private:
+  /**
  * server we are connected to
  *
  */
-			std::string m_redis_server;
-/**
+  std::string m_redis_server;
+  /**
  * port we are connected to
  *
  */
-			std::size_t m_redis_port = 0;
-/**
+  std::size_t m_redis_port = 0;
+  /**
  * master name (if we are using sentinel) we are connected to
  *
  */
-			std::string m_master_name;
-/**
+  std::string m_master_name;
+  /**
  * password used to authenticate
  *
  */
-			std::string m_password;
-/**
+  std::string m_password;
+  /**
  * selected redis db
  *
  */
-			int m_database_index = 0;
+  int m_database_index = 0;
 
-/**
+  /**
  * tcp client for redis connection
  *
  */
-			network::redis_connection m_client;
+  network::redis_connection m_client;
 
-/**
+  /**
  * redis sentinel
  *
  */
-			cpp_redis::sentinel m_sentinel;
+  cpp_redis::sentinel m_sentinel;
 
-/**
+  /**
  * max time to connect
  *
  */
-			std::uint32_t m_connect_timeout_ms = 0;
-/**
+  std::uint32_t m_connect_timeout_ms = 0;
+  /**
  * max number of reconnection attempts
  *
  */
-			std::int32_t m_max_reconnects = 0;
-/**
+  std::int32_t m_max_reconnects = 0;
+  /**
  * current number of attempts to reconnect
  *
  */
-			std::int32_t m_current_reconnect_attempts = 0;
-/**
+  std::int32_t m_current_reconnect_attempts = 0;
+  /**
  * time between two reconnection attempts
  *
  */
-			std::uint32_t m_reconnect_interval_ms = 0;
+  std::uint32_t m_reconnect_interval_ms = 0;
 
-/**
+  /**
  * reconnection status
  *
  */
-			std::atomic_bool m_reconnecting;
-/**
+  std::atomic_bool m_reconnecting;
+  /**
  * to force cancel reconnection
  *
  */
-			std::atomic_bool m_cancel;
+  std::atomic_bool m_cancel;
 
-/**
+  /**
  * sent commands waiting to be executed
  *
  */
-			std::queue<command_request> m_commands;
+  std::queue<command_request> m_commands;
 
-/**
+  /**
  * user defined connect status callback
  *
  */
-			connect_callback_t m_connect_callback;
+  connect_callback_t m_connect_callback;
 
-/**
+  /**
  *  callbacks thread safety
  *
  */
-			std::mutex m_callbacks_mutex;
+  std::mutex m_callbacks_mutex;
 
-/**
+  /**
  * condvar for callbacks updates
  *
  */
-			std::condition_variable m_sync_condvar;
+  std::condition_variable m_sync_condvar;
 
-/**
+  /**
  * number of callbacks currently being running
  *
  */
-			std::atomic<unsigned int> m_callbacks_running;
-	}; // namespace cpp_redis
+  std::atomic<unsigned int> m_callbacks_running;
+}; // namespace cpp_redis
 
 } // namespace cpp_redis
 

--- a/includes/cpp_redis/core/consumer.hpp
+++ b/includes/cpp_redis/core/consumer.hpp
@@ -23,58 +23,58 @@
 #ifndef CPP_REDIS_CONSUMER_HPP
 #define CPP_REDIS_CONSUMER_HPP
 
-#include <string>
 #include <cpp_redis/core/client.hpp>
 #include <cpp_redis/misc/dispatch_queue.hpp>
+#include <string>
 
 namespace cpp_redis {
 
-	using defer = std::shared_ptr<void>;
+using defer = std::shared_ptr<void>;
 
 /**
  * reply callback called whenever a reply is received
  * takes as parameter the received reply
  */
-	typedef dispatch_callback_t consumer_callback_t;
+typedef dispatch_callback_t consumer_callback_t;
 
-	typedef client::reply_callback_t reply_callback_t;
+typedef client::reply_callback_t reply_callback_t;
 
-	typedef struct consumer_callback_container {
-			consumer_callback_t consumer_callback;
-			acknowledgement_callback_t acknowledgement_callback;
-	} consumer_callback_container_t;
+typedef struct consumer_callback_container {
+  consumer_callback_t consumer_callback;
+  acknowledgement_callback_t acknowledgement_callback;
+} consumer_callback_container_t;
 
-	typedef struct consumer_reply {
-			std::string group_id;
-			xstream_reply_t reply;
-	} consumer_reply_t;
+typedef struct consumer_reply {
+  std::string group_id;
+  xstream_reply_t reply;
+} consumer_reply_t;
 
-	class consumer_client_container {
-	public:
-			consumer_client_container();
+class consumer_client_container {
+public:
+  consumer_client_container();
 
-			client ack_client;
-			client poll_client;
-	};
+  client ack_client;
+  client poll_client;
+};
 
-	typedef consumer_client_container consumer_client_container_t;
+typedef consumer_client_container consumer_client_container_t;
 
-	typedef std::unique_ptr<consumer_client_container_t> client_container_ptr_t;
+typedef std::unique_ptr<consumer_client_container_t> client_container_ptr_t;
 
-	typedef std::multimap<std::string, consumer_callback_container_t> consumer_callbacks_t;
+typedef std::multimap<std::string, consumer_callback_container_t> consumer_callbacks_t;
 
-	//typedef std::map<std::string, consumer_callback_container_t> consumer_callbacks_t;
+//typedef std::map<std::string, consumer_callback_container_t> consumer_callbacks_t;
 
-	class consumer {
-	public:
-			explicit consumer(std::string stream, std::string consumer,
-			                  size_t max_concurrency = std::thread::hardware_concurrency());
+class consumer {
+public:
+  explicit consumer(std::string stream, std::string consumer,
+    size_t max_concurrency = std::thread::hardware_concurrency());
 
-			consumer &subscribe(const std::string &group,
-			                    const consumer_callback_t &consumer_callback,
-			                    const acknowledgement_callback_t &acknowledgement_callback = nullptr);
+  consumer& subscribe(const std::string& group,
+    const consumer_callback_t& consumer_callback,
+    const acknowledgement_callback_t& acknowledgement_callback = nullptr);
 
-			/**
+  /**
 			 * @brief Connect to redis server
 			 * @param host host to be connected to
 			 * @param port port to be connected to
@@ -83,51 +83,51 @@ namespace cpp_redis {
 			 * @param max_reconnects maximum attempts of reconnection if connection dropped
 			 * @param reconnect_interval_ms time between two attempts of reconnection
 			 */
-			void connect(
-					const std::string &host = "127.0.0.1",
-					std::size_t port = 6379,
-					const connect_callback_t &connect_callback = nullptr,
-					std::uint32_t timeout_ms = 0,
-					std::int32_t max_reconnects = 0,
-					std::uint32_t reconnect_interval_ms = 0);
+  void connect(
+    const std::string& host                    = "127.0.0.1",
+    std::size_t port                           = 6379,
+    const connect_callback_t& connect_callback = nullptr,
+    std::uint32_t timeout_ms                   = 0,
+    std::int32_t max_reconnects                = 0,
+    std::uint32_t reconnect_interval_ms        = 0);
 
-			void auth(const std::string &password,
-			          const reply_callback_t &reply_callback = nullptr);
+  void auth(const std::string& password,
+    const reply_callback_t& reply_callback = nullptr);
 
-			/*
+  /*
 			 * commit pipelined transaction
 			 * that is, send to the network all commands pipelined by calling send() / subscribe() / ...
 			 *
 			 * @return current instance
 			 */
-			consumer &commit();
+  consumer& commit();
 
-			void dispatch_changed_handler(size_t size);
+  void dispatch_changed_handler(size_t size);
 
-	private:
-			void poll();
+private:
+  void poll();
 
-	private:
-			std::string m_stream;
-			std::string m_name;
-			std::string m_read_id;
-			int m_block_sec;
-			size_t m_max_concurrency;
-			int m_read_count;
+private:
+  std::string m_stream;
+  std::string m_name;
+  std::string m_read_id;
+  int m_block_sec;
+  size_t m_max_concurrency;
+  int m_read_count;
 
-			client_container_ptr_t m_client;
+  client_container_ptr_t m_client;
 
-			consumer_callbacks_t m_callbacks;
-			std::mutex m_callbacks_mutex;
+  consumer_callbacks_t m_callbacks;
+  std::mutex m_callbacks_mutex;
 
-			dispatch_queue_ptr_t m_dispatch_queue;
-			std::atomic_bool dispatch_queue_full{false};
-			std::condition_variable dispatch_queue_changed;
-			std::mutex dispatch_queue_changed_mutex;
+  dispatch_queue_ptr_t m_dispatch_queue;
+  std::atomic_bool dispatch_queue_full{false};
+  std::condition_variable dispatch_queue_changed;
+  std::mutex dispatch_queue_changed_mutex;
 
-			bool is_ready = false;
-			std::atomic_bool m_should_read_pending{true};
-	};
+  bool is_ready = false;
+  std::atomic_bool m_should_read_pending{true};
+};
 
 } // namespace cpp_redis
 

--- a/includes/cpp_redis/core/reply.hpp
+++ b/includes/cpp_redis/core/reply.hpp
@@ -37,8 +37,8 @@ namespace cpp_redis {
  * That is, cpp_redis::reply objects are passed as parameters of commands callbacks and contain the server's response.
  *
  */
-	class reply {
-	public:
+class reply {
+public:
 #define __CPP_REDIS_REPLY_ERR 0
 #define __CPP_REDIS_REPLY_BULK 1
 #define __CPP_REDIS_REPLY_SIMPLE 2
@@ -46,238 +46,238 @@ namespace cpp_redis {
 #define __CPP_REDIS_REPLY_INT 4
 #define __CPP_REDIS_REPLY_ARRAY 5
 
-/**
+  /**
  * type of reply, based on redis server standard replies
  *
  */
-			enum class type {
-					error = __CPP_REDIS_REPLY_ERR,
-					bulk_string = __CPP_REDIS_REPLY_BULK,
-					simple_string = __CPP_REDIS_REPLY_SIMPLE,
-					null = __CPP_REDIS_REPLY_NULL,
-					integer = __CPP_REDIS_REPLY_INT,
-					array = __CPP_REDIS_REPLY_ARRAY
-			};
+  enum class type {
+    error         = __CPP_REDIS_REPLY_ERR,
+    bulk_string   = __CPP_REDIS_REPLY_BULK,
+    simple_string = __CPP_REDIS_REPLY_SIMPLE,
+    null          = __CPP_REDIS_REPLY_NULL,
+    integer       = __CPP_REDIS_REPLY_INT,
+    array         = __CPP_REDIS_REPLY_ARRAY
+  };
 
-/**
+  /**
  * specific type of replies for string-based replies
  *
  */
-			enum class string_type {
-					error = __CPP_REDIS_REPLY_ERR,
-					bulk_string = __CPP_REDIS_REPLY_BULK,
-					simple_string = __CPP_REDIS_REPLY_SIMPLE
-			};
+  enum class string_type {
+    error         = __CPP_REDIS_REPLY_ERR,
+    bulk_string   = __CPP_REDIS_REPLY_BULK,
+    simple_string = __CPP_REDIS_REPLY_SIMPLE
+  };
 
-	public:
-/**
+public:
+  /**
  * default ctor (set a null reply)
  *
  */
-			reply();
+  reply();
 
-/**
+  /**
  * ctor for string values
  *
  * @param value string value
  * @param reply_type of string reply
  *
  */
-			reply(const std::string &value, string_type reply_type);
+  reply(const std::string& value, string_type reply_type);
 
-/**
+  /**
  * ctor for int values
  *
  * @param value integer value
  *
  */
-			explicit reply(int64_t value);
+  explicit reply(int64_t value);
 
-/**
+  /**
  * ctor for array values
  *
  * @param rows array reply
  * @return current instance
  *
  */
-			explicit reply(const std::vector<reply> &rows);
+  explicit reply(const std::vector<reply>& rows);
 
-/**
+  /**
  * dtor
  *
  */
-			~reply() = default;
+  ~reply() = default;
 
-/**
+  /**
  * copy ctor
  *
  */
-			reply(const reply &) = default;
+  reply(const reply&) = default;
 
-/**
+  /**
  * assignment operator
  *
  */
-			reply &operator=(const reply &) = default;
+  reply& operator=(const reply&) = default;
 
-/**
+  /**
  * move ctor
  *
  */
-			reply(reply &&) noexcept;
+  reply(reply&&) noexcept;
 
-/**
+  /**
  * move assignment operator
  *
  */
-			reply &operator=(reply &&) noexcept;
+  reply& operator=(reply&&) noexcept;
 
-	public:
-/**
+public:
+  /**
  * @return whether the reply is an array
  *
  */
-			bool is_array() const;
+  bool is_array() const;
 
-/**
+  /**
  * @return whether the reply is a string (simple, bulk, error)
  *
  */
-			bool is_string() const;
+  bool is_string() const;
 
-/**
+  /**
  * @return whether the reply is a simple string
  *
  */
-			bool is_simple_string() const;
+  bool is_simple_string() const;
 
-/**
+  /**
  * @return whether the reply is a bulk string
  *
  */
-			bool is_bulk_string() const;
+  bool is_bulk_string() const;
 
-/**
+  /**
  * @return whether the reply is an error
  *
  */
-			bool is_error() const;
+  bool is_error() const;
 
-/**
+  /**
  * @return whether the reply is an integer
  *
  */
-			bool is_integer() const;
+  bool is_integer() const;
 
-/**
+  /**
  * @return whether the reply is null
  *
  */
-			bool is_null() const;
+  bool is_null() const;
 
-	public:
-/**
+public:
+  /**
  * @return true if function is not an error
  *
  */
-			bool ok() const;
+  bool ok() const;
 
-/**
+  /**
  * @return true if function is an error
  *
  */
-			bool ko() const;
+  bool ko() const;
 
-/**
+  /**
  * convenience implicit conversion, same as !is_null() / ok()
  *
  */
-			explicit operator bool() const;
+  explicit operator bool() const;
 
-	public:
-			optional_t<int64_t> try_get_int() const;
+public:
+  optional_t<int64_t> try_get_int() const;
 
-	public:
-/**
+public:
+  /**
  * @return the underlying error
  *
  */
-			const std::string &error() const;
+  const std::string& error() const;
 
-/**
+  /**
  * @return the underlying array
  *
  */
-			const std::vector<reply> &as_array() const;
+  const std::vector<reply>& as_array() const;
 
-/**
+  /**
  * @return the underlying string
  *
  */
-			const std::string &as_string() const;
+  const std::string& as_string() const;
 
-/**
+  /**
  * @return the underlying integer
  *
  */
-			int64_t as_integer() const;
+  int64_t as_integer() const;
 
-	public:
-/**
+public:
+  /**
  * set reply as null
  *
  */
-			void set();
+  void set();
 
-/**
+  /**
  * set a string reply
  *
  * @param value string value
  * @param reply_type of string reply
  *
  */
-			void set(const std::string &value, string_type reply_type);
+  void set(const std::string& value, string_type reply_type);
 
-/**
+  /**
  * set an integer reply
  *
  * @param value integer value
  *
  */
-			void set(int64_t value);
+  void set(int64_t value);
 
-/**
+  /**
  * set an array reply
  *
  * @param rows array reply
  *
  */
-			void set(const std::vector<reply> &rows);
+  void set(const std::vector<reply>& rows);
 
-/**
+  /**
  * for array replies, add a new row to the reply
  *
  * @param reply new row to be appended
  * @return current instance
  *
  */
-			reply &operator<<(const reply &reply);
+  reply& operator<<(const reply& reply);
 
-	public:
-/**
+public:
+  /**
  * @return reply type
  *
  */
-			type get_type() const;
+  type get_type() const;
 
-	private:
-			type m_type;
-			std::vector<cpp_redis::reply> m_rows;
-			std::string m_str_val;
-			int64_t m_int_val;
-	};
+private:
+  type m_type;
+  std::vector<cpp_redis::reply> m_rows;
+  std::string m_str_val;
+  int64_t m_int_val;
+};
 
-	typedef reply reply_t;
+typedef reply reply_t;
 
 } // namespace cpp_redis
 
@@ -285,4 +285,4 @@ namespace cpp_redis {
  * support for output
  *
  */
-std::ostream &operator<<(std::ostream &os, const cpp_redis::reply_t &reply);
+std::ostream& operator<<(std::ostream& os, const cpp_redis::reply_t& reply);

--- a/includes/cpp_redis/core/subscriber.hpp
+++ b/includes/cpp_redis/core/subscriber.hpp
@@ -42,46 +42,46 @@ namespace cpp_redis {
  *  * cpp_redis::client is not meant for that
  *
  */
-	class subscriber {
-	public:
+class subscriber {
+public:
 #ifndef __CPP_REDIS_USE_CUSTOM_TCP_CLIENT
 
-/**
+  /**
  * ctor
  *
  */
-			subscriber();
+  subscriber();
 
 #endif /* __CPP_REDIS_USE_CUSTOM_TCP_CLIENT */
 
-/**
+  /**
  * custom ctor to specify custom tcp_client
  *
  * @param tcp_client tcp client to be used for network communications
  *
  */
-			explicit subscriber(const std::shared_ptr<network::tcp_client_iface> &tcp_client);
+  explicit subscriber(const std::shared_ptr<network::tcp_client_iface>& tcp_client);
 
-/**
+  /**
  * dtor
  *
  */
-			~subscriber();
+  ~subscriber();
 
-/**
+  /**
  * copy ctor
  *
  */
-			subscriber(const subscriber &) = delete;
+  subscriber(const subscriber&) = delete;
 
-/**
+  /**
  * assignment operator
  *
  */
-			subscriber &operator=(const subscriber &) = delete;
+  subscriber& operator=(const subscriber&) = delete;
 
-	public:
-/**
+public:
+  /**
  * @brief Connect to redis server
  * @param host host to be connected to
  * @param port port to be connected to
@@ -91,15 +91,15 @@ namespace cpp_redis {
  * @param reconnect_interval_ms time between two attempts of reconnection
  *
  */
-			void connect(
-					const std::string &host = "127.0.0.1",
-					std::size_t port = 6379,
-					const connect_callback_t &connect_callback = nullptr,
-					std::uint32_t timeout_ms = 0,
-					std::int32_t max_reconnects = 0,
-					std::uint32_t reconnect_interval_ms = 0);
+  void connect(
+    const std::string& host                    = "127.0.0.1",
+    std::size_t port                           = 6379,
+    const connect_callback_t& connect_callback = nullptr,
+    std::uint32_t timeout_ms                   = 0,
+    std::int32_t max_reconnects                = 0,
+    std::uint32_t reconnect_interval_ms        = 0);
 
-/**
+  /**
  * @brief Connect to redis server
  * @param name sentinel name
  * @param connect_callback connect handler to be called on connect events (may be null)
@@ -108,48 +108,48 @@ namespace cpp_redis {
  * @param reconnect_interval_ms time between two attempts of reconnection
  *
  */
-			void connect(
-					const std::string &name,
-					const connect_callback_t &connect_callback = nullptr,
-					std::uint32_t timeout_ms = 0,
-					std::int32_t max_reconnects = 0,
-					std::uint32_t reconnect_interval_ms = 0);
+  void connect(
+    const std::string& name,
+    const connect_callback_t& connect_callback = nullptr,
+    std::uint32_t timeout_ms                   = 0,
+    std::int32_t max_reconnects                = 0,
+    std::uint32_t reconnect_interval_ms        = 0);
 
-/**
+  /**
  * @brief determines client connectivity
  * @return whether we are connected to the redis server
  *
  */
-			bool is_connected() const;
+  bool is_connected() const;
 
-/**
+  /**
  * @brief disconnect from redis server
  * @param wait_for_removal when set to true, disconnect blocks until the underlying TCP client has been effectively removed from the io_service and that all the underlying callbacks have completed.
  *
  */
-			void disconnect(bool wait_for_removal = false);
+  void disconnect(bool wait_for_removal = false);
 
-/**
+  /**
  * @brief determines if reconnect is in progress
  * @return whether an attempt to reconnect is in progress
  *
  */
-			bool is_reconnecting() const;
+  bool is_reconnecting() const;
 
-/**
+  /**
  * @brief stop any reconnect in progress
  *
  */
-			void cancel_reconnect();
+  void cancel_reconnect();
 
-	public:
-/**
+public:
+  /**
  * @brief reply callback called whenever a reply is received, takes as parameter the received reply
  *
  */
-			typedef std::function<void(reply &)> reply_callback_t;
+  typedef std::function<void(reply&)> reply_callback_t;
 
-/**
+  /**
  * @brief ability to authenticate on the redis server if necessary
  * this method should not be called repeatedly as the storage of reply_callback is NOT thread safe (only one reply callback is stored for the subscriber client)
  * calling repeatedly auth() is undefined concerning the execution of the associated callbacks
@@ -158,9 +158,9 @@ namespace cpp_redis {
  * @return current instance
  *
  */
-			subscriber &auth(const std::string &password, const reply_callback_t &reply_callback = nullptr);
+  subscriber& auth(const std::string& password, const reply_callback_t& reply_callback = nullptr);
 
-/**
+  /**
  * @brief Set the label for the connection on the Redis server via the CLIENT SETNAME command.
  * This is useful for monitoring and managing connections on the server side of things.
  * @param name - string to label the connection with on the server side
@@ -168,16 +168,16 @@ namespace cpp_redis {
  * @return current instance
  *
  */
-			subscriber& client_setname(const std::string& name, const reply_callback_t& reply_callback = nullptr);
+  subscriber& client_setname(const std::string& name, const reply_callback_t& reply_callback = nullptr);
 
-/**
+  /**
  * subscribe callback, called whenever a new message is published on a subscribed channel
  * takes as parameter the channel and the message
  *
  */
-			typedef std::function<void(const std::string &, const std::string &)> subscribe_callback_t;
+  typedef std::function<void(const std::string&, const std::string&)> subscribe_callback_t;
 
-/**
+  /**
  * Subscribes to the given channel and:
  *  * calls acknowledgement_callback once the server has acknowledged about the subscription.
  *  * calls subscribe_callback each time a message is published on this channel.
@@ -188,11 +188,11 @@ namespace cpp_redis {
  * @param acknowledgement_callback callback to be called on subscription completion (nullable)
  * @return current instance
  */
-//!
-			subscriber &subscribe(const std::string &channel, const subscribe_callback_t &callback,
-			                      const acknowledgement_callback_t &acknowledgement_callback = nullptr);
+  //!
+  subscriber& subscribe(const std::string& channel, const subscribe_callback_t& callback,
+    const acknowledgement_callback_t& acknowledgement_callback = nullptr);
 
-/**
+  /**
  * PSubscribes to the given channel and:
  *  * calls acknowledgement_callback once the server has acknowledged about the subscription.
  *  * calls subscribe_callback each time a message is published on this channel.
@@ -203,11 +203,11 @@ namespace cpp_redis {
  * @param acknowledgement_callback callback to be called on subscription completion (nullable)
  * @return current instance
  */
-//!
-			subscriber &psubscribe(const std::string &pattern, const subscribe_callback_t &callback,
-			                       const acknowledgement_callback_t &acknowledgement_callback = nullptr);
+  //!
+  subscriber& psubscribe(const std::string& pattern, const subscribe_callback_t& callback,
+    const acknowledgement_callback_t& acknowledgement_callback = nullptr);
 
-/**
+  /**
  * unsubscribe from the given channel
  * The command is not effectively sent immediately, but stored inside an internal buffer until commit() is called.
  *
@@ -215,9 +215,9 @@ namespace cpp_redis {
  * @return current instance
  *
  */
-			subscriber &unsubscribe(const std::string &channel);
+  subscriber& unsubscribe(const std::string& channel);
 
-/**
+  /**
  * punsubscribe from the given pattern
  * The command is not effectively sent immediately, but stored inside an internal buffer until commit() is called.
  *
@@ -225,19 +225,19 @@ namespace cpp_redis {
  * @return current instance
  *
  */
-			subscriber &punsubscribe(const std::string &pattern);
+  subscriber& punsubscribe(const std::string& pattern);
 
-/**
+  /**
  * commit pipelined transaction
  * that is, send to the network all commands pipelined by calling send() / subscribe() / ...
  *
  * @return current instance
  *
  */
-			subscriber &commit();
+  subscriber& commit();
 
-	public:
-/**
+public:
+  /**
  * add a sentinel definition. Required for connect() or get_master_addr_by_name() when autoconnect is enabled.
  *
  * @param host sentinel host
@@ -245,87 +245,87 @@ namespace cpp_redis {
  * @param timeout_ms maximum time to connect
  *
  */
-			void add_sentinel(const std::string &host, std::size_t port, std::uint32_t timeout_ms = 0);
+  void add_sentinel(const std::string& host, std::size_t port, std::uint32_t timeout_ms = 0);
 
-/**
+  /**
  * retrieve sentinel for current client
  *
  * @return sentinel associated to current client
  *
  */
-			const sentinel &get_sentinel() const;
+  const sentinel& get_sentinel() const;
 
-/**
+  /**
  * retrieve sentinel for current client
  * non-const version
  *
  * @return sentinel associated to current client
  *
  */
-			sentinel &get_sentinel();
+  sentinel& get_sentinel();
 
-/**
+  /**
  * clear all existing sentinels.
  *
  */
-			void clear_sentinels();
+  void clear_sentinels();
 
-	private:
-/**
+private:
+  /**
  * struct to hold callbacks (sub and ack) for a given channel or pattern
  *
  */
-			struct callback_holder {
-					subscribe_callback_t subscribe_callback;
-					acknowledgement_callback_t acknowledgement_callback;
-			};
+  struct callback_holder {
+    subscribe_callback_t subscribe_callback;
+    acknowledgement_callback_t acknowledgement_callback;
+  };
 
-	private:
-/**
+private:
+  /**
  * redis connection receive handler, triggered whenever a reply has been read by the redis connection
  *
  * @param connection redis_connection instance
  * @param reply parsed reply
  *
  */
-			void connection_receive_handler(network::redis_connection &connection, reply &reply);
+  void connection_receive_handler(network::redis_connection& connection, reply& reply);
 
-/**
+  /**
  * redis_connection disconnection handler, triggered whenever a disconnection occurred
  *
  * @param connection redis_connection instance
  *
  */
-			void connection_disconnection_handler(network::redis_connection &connection);
+  void connection_disconnection_handler(network::redis_connection& connection);
 
-/**
+  /**
  * trigger the ack callback for matching channel/pattern
  * check if reply is valid
  *
  * @param reply received reply
  *
  */
-			void handle_acknowledgement_reply(const std::vector<reply> &reply);
+  void handle_acknowledgement_reply(const std::vector<reply>& reply);
 
-/**
+  /**
  * trigger the sub callback for all matching channels/patterns
  * check if reply is valid
  *
  * @param reply received reply
  *
  */
-			void handle_subscribe_reply(const std::vector<reply> &reply);
+  void handle_subscribe_reply(const std::vector<reply>& reply);
 
-/**
+  /**
  * trigger the sub callback for all matching channels/patterns
  * check if reply is valid
  *
  * @param reply received reply
  *
  */
-			void handle_psubscribe_reply(const std::vector<reply> &reply);
+  void handle_psubscribe_reply(const std::vector<reply>& reply);
 
-/**
+  /**
  * find channel or pattern that is associated to the reply and call its ack callback
  *
  * @param channel channel or pattern that caused the issuance of this reply
@@ -334,56 +334,56 @@ namespace cpp_redis {
  * @param nb_chans redis server ack reply
  *
  */
-			void
-			call_acknowledgement_callback(const std::string &channel, const std::map<std::string, callback_holder> &channels,
-			                              std::mutex &channels_mtx, int64_t nb_chans);
+  void
+  call_acknowledgement_callback(const std::string& channel, const std::map<std::string, callback_holder>& channels,
+    std::mutex& channels_mtx, int64_t nb_chans);
 
-	private:
-/**
+private:
+  /**
  * reconnect to the previously connected host
  * automatically re authenticate and resubscribe to subscribed channel in case of success
  *
  */
-			void reconnect();
+  void reconnect();
 
-/**
+  /**
  * re authenticate to redis server based on previously used password
  *
  */
-			void re_auth();
+  void re_auth();
 
-/**
+  /**
  * re send CLIENT SETNAME to redis server based on previously used name
  *
  */
-			void re_client_setname(void);
+  void re_client_setname(void);
 
-/**
+  /**
  * resubscribe (sub and psub) to previously subscribed channels/patterns
  *
  */
-			void re_subscribe();
+  void re_subscribe();
 
-/**
+  /**
  * @return whether a reconnection attempt should be performed
  *
  */
-			bool should_reconnect() const;
+  bool should_reconnect() const;
 
-/**
+  /**
  * sleep between two reconnect attempts if necessary
  *
  */
-			void sleep_before_next_reconnect_attempt();
+  void sleep_before_next_reconnect_attempt();
 
-/**
+  /**
  * clear all subscriptions (dirty way, no unsub/punsub commands send: mostly used for cleaning in disconnection condition)
  *
  */
-			void clear_subscriptions();
+  void clear_subscriptions();
 
-	private:
-/**
+private:
+  /**
  * unprotected sub
  * same as subscribe, but without any mutex lock
  *
@@ -392,10 +392,10 @@ namespace cpp_redis {
  * @param acknowledgement_callback callback to be called on subscription completion (nullable)
  *
  */
-			void unprotected_subscribe(const std::string &channel, const subscribe_callback_t &callback,
-			                           const acknowledgement_callback_t &acknowledgement_callback);
+  void unprotected_subscribe(const std::string& channel, const subscribe_callback_t& callback,
+    const acknowledgement_callback_t& acknowledgement_callback);
 
-/**
+  /**
  * unprotected psub
  * same as psubscribe, but without any mutex lock
  *
@@ -404,120 +404,120 @@ namespace cpp_redis {
  * @param acknowledgement_callback callback to be called on subscription completion (nullable)
  *
  */
-			void unprotected_psubscribe(const std::string &pattern, const subscribe_callback_t &callback,
-			                            const acknowledgement_callback_t &acknowledgement_callback);
+  void unprotected_psubscribe(const std::string& pattern, const subscribe_callback_t& callback,
+    const acknowledgement_callback_t& acknowledgement_callback);
 
-	private:
-/**
+private:
+  /**
  * server we are connected to
  *
  */
-			std::string m_redis_server;
-/**
+  std::string m_redis_server;
+  /**
  * port we are connected to
  *
  */
-			std::size_t m_redis_port = 0;
-/**
+  std::size_t m_redis_port = 0;
+  /**
  * master name (if we are using sentinel) we are connected to
  *
  */
-			std::string m_master_name;
-/**
+  std::string m_master_name;
+  /**
  * password used to authenticate
  *
  */
-			std::string m_password;
+  std::string m_password;
 
-/**
+  /**
  * name to use with CLIENT SETNAME
  *
  */
-			std::string m_client_name;
+  std::string m_client_name;
 
-/**
+  /**
  * tcp client for redis connection
  *
  */
-			network::redis_connection m_client;
+  network::redis_connection m_client;
 
-/**
+  /**
  * redis sentinel
  *
  */
-			cpp_redis::sentinel m_sentinel;
+  cpp_redis::sentinel m_sentinel;
 
-/**
+  /**
  * max time to connect
  *
  */
-			std::uint32_t m_connect_timeout_ms = 0;
-/**
+  std::uint32_t m_connect_timeout_ms = 0;
+  /**
  * max number of reconnection attempts
  *
  */
-			std::int32_t m_max_reconnects = 0;
-/**
+  std::int32_t m_max_reconnects = 0;
+  /**
  * current number of attempts to reconnect
  *
  */
-			std::int32_t m_current_reconnect_attempts = 0;
-/**
+  std::int32_t m_current_reconnect_attempts = 0;
+  /**
  * time between two reconnection attempts
  *
  */
-			std::uint32_t m_reconnect_interval_ms = 0;
+  std::uint32_t m_reconnect_interval_ms = 0;
 
-/**
+  /**
  * reconnection status
  *
  */
-			std::atomic_bool m_reconnecting;
-/**
+  std::atomic_bool m_reconnecting;
+  /**
  * to force cancel reconnection
  *
  */
-			std::atomic_bool m_cancel;
+  std::atomic_bool m_cancel;
 
-/**
+  /**
  * subscribed channels and their associated channels
  *
  */
-			std::map<std::string, callback_holder> m_subscribed_channels;
-/**
+  std::map<std::string, callback_holder> m_subscribed_channels;
+  /**
  * psubscribed channels and their associated channels
  *
  */
-			std::map<std::string, callback_holder> m_psubscribed_channels;
+  std::map<std::string, callback_holder> m_psubscribed_channels;
 
-/**
+  /**
  * connect handler
  *
  */
-			connect_callback_t m_connect_callback;
+  connect_callback_t m_connect_callback;
 
-/**
+  /**
  * sub chans thread safety
  *
  */
-			std::mutex m_psubscribed_channels_mutex;
-/**
+  std::mutex m_psubscribed_channels_mutex;
+  /**
  * psub chans thread safety
  *
  */
-			std::mutex m_subscribed_channels_mutex;
+  std::mutex m_subscribed_channels_mutex;
 
-/**
+  /**
  * auth reply callback
  *
  */
-			reply_callback_t m_auth_reply_callback;
+  reply_callback_t m_auth_reply_callback;
 
-/**
+  /**
  * client setname reply callback
  *
  */
-			reply_callback_t m_client_setname_reply_callback;
-	};
+  reply_callback_t m_client_setname_reply_callback;
+};
 
 } // namespace cpp_redis

--- a/includes/cpp_redis/core/types.hpp
+++ b/includes/cpp_redis/core/types.hpp
@@ -23,125 +23,126 @@
 #ifndef CPP_REDIS_CORE_TYPES_HPP
 #define CPP_REDIS_CORE_TYPES_HPP
 
+#include <cpp_redis/core/reply.hpp>
+#include <cpp_redis/impl/types.hpp>
+#include <chrono>
+#include <ctime>
+#include <functional>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
-#include <ctime>
-#include <chrono>
-#include <cpp_redis/core/reply.hpp>
-#include <functional>
-#include <cpp_redis/impl/types.hpp>
 
 
 namespace cpp_redis {
-	typedef std::int64_t ms;
+typedef std::int64_t ms;
 /**
  * @brief first array is the session name, second is ids
  *
  */
-	typedef std::pair<std::vector<std::string>, std::vector<std::string>> streams_t;
+typedef std::pair<std::vector<std::string>, std::vector<std::string>> streams_t;
 
-	/**
+/**
 	 * @brief Options
 	 */
 
-	typedef struct xread_options {
-			streams_t Streams;
-			std::int64_t Count;
-			std::int64_t Block;
-	} xread_options_t;
+typedef struct xread_options {
+  streams_t Streams;
+  std::int64_t Count;
+  std::int64_t Block;
+} xread_options_t;
 
-	typedef struct xreadgroup_options {
-			std::string Group;
-			std::string Consumer;
-			streams_t Streams;
-			std::int64_t Count;
-			std::int64_t Block;
-			bool NoAck;
-	} xreadgroup_options_t;
+typedef struct xreadgroup_options {
+  std::string Group;
+  std::string Consumer;
+  streams_t Streams;
+  std::int64_t Count;
+  std::int64_t Block;
+  bool NoAck;
+} xreadgroup_options_t;
 
-	typedef struct range_options {
-			std::string Start;
-			std::string Stop;
-			std::int64_t Count;
-	} range_options_t;
+typedef struct range_options {
+  std::string Start;
+  std::string Stop;
+  std::int64_t Count;
+} range_options_t;
 
-	typedef struct xclaim_options {
-			std::int64_t Idle;
-			std::time_t *Time;
-			std::int64_t RetryCount;
-			bool Force;
-			bool JustId;
-	} xclaim_options_t;
+typedef struct xclaim_options {
+  std::int64_t Idle;
+  std::time_t* Time;
+  std::int64_t RetryCount;
+  bool Force;
+  bool JustId;
+} xclaim_options_t;
 
-	typedef struct xpending_options {
-			range_options_t Range;
-			std::string Consumer;
-	} xpending_options_t;
+typedef struct xpending_options {
+  range_options_t Range;
+  std::string Consumer;
+} xpending_options_t;
 
-	/**
+/**
 	 * @brief Replies
 	 */
 
-	class xmessage : public message_type {
-	public:
-			xmessage();
+class xmessage : public message_type {
+public:
+  xmessage();
 
-			explicit xmessage(const reply_t &data);
+  explicit xmessage(const reply_t& data);
 
-			friend std::ostream &operator<<(std::ostream &os, const xmessage &xm);
-			friend std::string operator<<(const std::string& is, const xmessage &xs);
-	};
+  friend std::ostream& operator<<(std::ostream& os, const xmessage& xm);
+  friend std::string operator<<(const std::string& is, const xmessage& xs);
+};
 
-	typedef xmessage xmessage_t;
+typedef xmessage xmessage_t;
 
-	class xstream {
-	public:
-			explicit xstream(const reply_t &data);
+class xstream {
+public:
+  explicit xstream(const reply_t& data);
 
-			friend std::ostream &operator<<(std::ostream &os, const xstream &xs);
-			friend std::string operator<<(const std::string& is, const xstream &xs);
+  friend std::ostream& operator<<(std::ostream& os, const xstream& xs);
+  friend std::string operator<<(const std::string& is, const xstream& xs);
 
-			std::string Stream;
-			std::vector<xmessage_t> Messages;
-	};
+  std::string Stream;
+  std::vector<xmessage_t> Messages;
+};
 
-	typedef xstream xstream_t;
+typedef xstream xstream_t;
 
-	class xinfo_reply {
-	public:
-			explicit xinfo_reply(const cpp_redis::reply &data);
+class xinfo_reply {
+public:
+  explicit xinfo_reply(const cpp_redis::reply& data);
 
-			std::int64_t Length;
-			std::int64_t RadixTreeKeys;
-			std::int64_t RadixTreeNodes;
-			std::int64_t Groups;
-			std::string LastGeneratedId;
-			xmessage_t FirstEntry;
-			xmessage_t LastEntry;
-	};
+  std::int64_t Length;
+  std::int64_t RadixTreeKeys;
+  std::int64_t RadixTreeNodes;
+  std::int64_t Groups;
+  std::string LastGeneratedId;
+  xmessage_t FirstEntry;
+  xmessage_t LastEntry;
+};
 
-	class xstream_reply : public std::vector<xstream_t> {
-	public:
-			explicit xstream_reply(const reply_t &data);
+class xstream_reply : public std::vector<xstream_t> {
+public:
+  explicit xstream_reply(const reply_t& data);
 
-			friend std::ostream &operator<<(std::ostream &os, const xstream_reply &xs);
-			friend std::string operator<<(const std::string& is, const xstream_reply &xs);
+  friend std::ostream& operator<<(std::ostream& os, const xstream_reply& xs);
+  friend std::string operator<<(const std::string& is, const xstream_reply& xs);
 
-	bool is_null() const {
-		if (empty())
-			return true;
-		for (auto &v : *this) {
-			if (v.Messages.empty())
-				return true;
-		}
-		return false;
-	}
-	};
+  bool
+  is_null() const {
+    if (empty())
+      return true;
+    for (auto& v : *this) {
+      if (v.Messages.empty())
+        return true;
+    }
+    return false;
+  }
+};
 
-	typedef xstream_reply xstream_reply_t;
+typedef xstream_reply xstream_reply_t;
 
-	/**
+/**
 	 * @brief Callbacks
 	 */
 
@@ -150,7 +151,7 @@ namespace cpp_redis {
  * takes as parameter the int returned by the redis server (usually the number of channels you are subscribed to)
  *
  */
-	typedef std::function<void(const int64_t &)> acknowledgement_callback_t;
+typedef std::function<void(const int64_t&)> acknowledgement_callback_t;
 
 /**
  * high availability (re)connection states
@@ -163,23 +164,23 @@ namespace cpp_redis {
  *  * stopped: stop to try to reconnect
  *
  */
-	enum class connect_state {
-			dropped,
-			start,
-			sleeping,
-			ok,
-			failed,
-			lookup_failed,
-			stopped
-	};
+enum class connect_state {
+  dropped,
+  start,
+  sleeping,
+  ok,
+  failed,
+  lookup_failed,
+  stopped
+};
 
 /**
  * connect handler, called whenever a new connection even occurred
  *
  */
-	typedef std::function<void(const std::string &host, std::size_t port, connect_state status)> connect_callback_t;
+typedef std::function<void(const std::string& host, std::size_t port, connect_state status)> connect_callback_t;
 
-	typedef std::function<void(const cpp_redis::message_type&)> message_callback_t;
+typedef std::function<void(const cpp_redis::message_type&)> message_callback_t;
 } // namespace cpp_redis
 
 

--- a/includes/cpp_redis/core/types.hpp
+++ b/includes/cpp_redis/core/types.hpp
@@ -90,6 +90,7 @@ namespace cpp_redis {
 			explicit xmessage(const reply_t &data);
 
 			friend std::ostream &operator<<(std::ostream &os, const xmessage &xm);
+			friend std::string operator<<(const std::string& is, const xmessage &xs);
 	};
 
 	typedef xmessage xmessage_t;
@@ -99,6 +100,7 @@ namespace cpp_redis {
 			explicit xstream(const reply_t &data);
 
 			friend std::ostream &operator<<(std::ostream &os, const xstream &xs);
+			friend std::string operator<<(const std::string& is, const xstream &xs);
 
 			std::string Stream;
 			std::vector<xmessage_t> Messages;
@@ -124,6 +126,7 @@ namespace cpp_redis {
 			explicit xstream_reply(const reply_t &data);
 
 			friend std::ostream &operator<<(std::ostream &os, const xstream_reply &xs);
+			friend std::string operator<<(const std::string& is, const xstream_reply &xs);
 
 	bool is_null() const {
 		if (empty())

--- a/includes/cpp_redis/helpers/generate_rand.hpp
+++ b/includes/cpp_redis/helpers/generate_rand.hpp
@@ -30,12 +30,13 @@
 #include <string>
 
 namespace cpp_redis {
-	inline std::string generate_rand() {
-		std::mt19937 rng;
-		rng.seed(std::random_device()());
-		std::uniform_int_distribution<std::mt19937::result_type> dist6(1,6); // distribution in range [1, 6]
-		return std::to_string(dist6(rng));
-	}
+inline std::string
+generate_rand() {
+  std::mt19937 rng;
+  rng.seed(std::random_device()());
+  std::uniform_int_distribution<std::mt19937::result_type> dist6(1, 6); // distribution in range [1, 6]
+  return std::to_string(dist6(rng));
 }
+} // namespace cpp_redis
 
 #endif //CPP_REDIS_GENERATE_RAND_HPP

--- a/includes/cpp_redis/helpers/variadic_template.hpp
+++ b/includes/cpp_redis/helpers/variadic_template.hpp
@@ -33,7 +33,7 @@ namespace helpers {
  */
 template <typename T, typename... Args>
 struct back {
-/**
+  /**
  * last type of variadic list
  *
  */
@@ -46,7 +46,7 @@ struct back {
  */
 template <typename T>
 struct back<T> {
-/**
+  /**
  * templated type
  *
  */
@@ -59,7 +59,7 @@ struct back<T> {
  */
 template <typename T, typename... Ts>
 struct front {
-/**
+  /**
  * front type of variadic list
  *
  */
@@ -72,7 +72,7 @@ struct front {
  */
 template <typename T1, typename T2, typename... Ts>
 struct is_type_present {
-/**
+  /**
  * true if T1 is present in remaining types of variadic list
  * false otherwise
  *
@@ -88,7 +88,7 @@ struct is_type_present {
  */
 template <typename T1, typename T2>
 struct is_type_present<T1, T2> {
-/**
+  /**
  * true if T1 and T2 are the same
  * false otherwise
  *
@@ -102,7 +102,7 @@ struct is_type_present<T1, T2> {
  */
 template <typename T, typename... Args>
 struct is_different_types {
-/**
+  /**
  * true if T is not in remaining types of variadic list
  * false otherwise
  *
@@ -118,7 +118,7 @@ struct is_different_types {
  */
 template <typename T1>
 struct is_different_types<T1> {
-/**
+  /**
  * true
  *
  */

--- a/includes/cpp_redis/impl/client.ipp
+++ b/includes/cpp_redis/impl/client.ipp
@@ -94,7 +94,7 @@ client::client_kill(const std::string& host, int port, const T& arg, const Ts&..
   static_assert(helpers::is_different_types<T, Ts...>::value, "Should only have one distinct value per filter type");
   std::vector<std::string> redis_cmd({"CLIENT", "KILL"});
 
-//! If we have other type than lambda, then it's a filter
+  //! If we have other type than lambda, then it's a filter
   if (!std::is_class<T>::value) {
     redis_cmd.emplace_back("ADDR");
   }
@@ -120,8 +120,8 @@ client::client_kill(const char* host, int port, const Ts&... args) {
 template <typename T, typename... Ts>
 std::future<reply>
 client::client_kill_future(const T arg, const Ts... args) {
-//! gcc 4.8 doesn't handle variadic template capture arguments (appears in 4.9)
-//! so std::bind should capture all arguments because of the compiler.
+  //! gcc 4.8 doesn't handle variadic template capture arguments (appears in 4.9)
+  //! so std::bind should capture all arguments because of the compiler.
   return exec_cmd(std::bind([this](T arg, Ts... args, const reply_callback_t& cb) -> client& {
     return client_kill(arg, args..., cb);
   },

--- a/includes/cpp_redis/impl/types.hpp
+++ b/includes/cpp_redis/impl/types.hpp
@@ -40,7 +40,7 @@ namespace cpp_redis {
 class serializer_type {
 public:
   inline serializer_type() {}
-  
+
   virtual ~serializer_type() {}
 
   /**

--- a/includes/cpp_redis/misc/convert.hpp
+++ b/includes/cpp_redis/misc/convert.hpp
@@ -22,27 +22,29 @@
 #ifndef CPP_REDIS_CONVERT_HPP
 #define CPP_REDIS_CONVERT_HPP
 
-#include <sstream>
 #include <cpp_redis/misc/optional.hpp>
+#include <sstream>
 
 namespace cpp_redis {
 
-	class try_convert {
-	public:
-			template <class T>
-			static enableIf<std::is_convertible<T, std::string>::value, optional_t<int64_t> > to_int(T value) {
-				try {
-					std::stringstream stream(value);
-					int64_t x;
-					stream >> x;
-					return optional_t<int64_t>(x);
-				} catch (std::exception &exc) {
-					return {};
-				}
-			}
-	};
+class try_convert {
+public:
+  template <class T>
+  static enableIf<std::is_convertible<T, std::string>::value, optional_t<int64_t>>
+  to_int(T value) {
+    try {
+      std::stringstream stream(value);
+      int64_t x;
+      stream >> x;
+      return optional_t<int64_t>(x);
+    }
+    catch (std::exception& exc) {
+      return {};
+    }
+  }
+};
 
-}
+} // namespace cpp_redis
 
 
 #endif //CPP_REDIS_CONVERT_HPP

--- a/includes/cpp_redis/misc/dispatch_queue.hpp
+++ b/includes/cpp_redis/misc/dispatch_queue.hpp
@@ -26,66 +26,66 @@
 #ifndef CPP_REDIS_DISPATCH_QUEUE_HPP
 #define CPP_REDIS_DISPATCH_QUEUE_HPP
 
-#include <thread>
-#include <functional>
-#include <vector>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdio>
-#include <queue>
+#include <functional>
 #include <mutex>
+#include <queue>
 #include <string>
-#include <condition_variable>
+#include <thread>
+#include <vector>
 
 #include <cpp_redis/impl/types.hpp>
 
 namespace cpp_redis {
-	typedef std::multimap<std::string, std::string> consumer_response_t;
+typedef std::multimap<std::string, std::string> consumer_response_t;
 
-	typedef std::function<consumer_response_t(const cpp_redis::message_type&)> dispatch_callback_t;
+typedef std::function<consumer_response_t(const cpp_redis::message_type&)> dispatch_callback_t;
 
-	typedef std::function<void(size_t size)> notify_callback_t;
+typedef std::function<void(size_t size)> notify_callback_t;
 
-	typedef struct dispatch_callback_collection {
-			dispatch_callback_t callback;
-			message_type message;
-	} dispatch_callback_collection_t;
+typedef struct dispatch_callback_collection {
+  dispatch_callback_t callback;
+  message_type message;
+} dispatch_callback_collection_t;
 
-	class dispatch_queue {
+class dispatch_queue {
 
-	public:
-			explicit dispatch_queue(std::string name, const notify_callback_t &notify_callback, size_t thread_cnt = 1);
-			~dispatch_queue();
+public:
+  explicit dispatch_queue(std::string name, const notify_callback_t& notify_callback, size_t thread_cnt = 1);
+  ~dispatch_queue();
 
-			// dispatch and copy
-			void dispatch(const cpp_redis::message_type& message, const dispatch_callback_t& op);
-			// dispatch and move
-			void dispatch(const cpp_redis::message_type& message, dispatch_callback_t&& op);
+  // dispatch and copy
+  void dispatch(const cpp_redis::message_type& message, const dispatch_callback_t& op);
+  // dispatch and move
+  void dispatch(const cpp_redis::message_type& message, dispatch_callback_t&& op);
 
-			// Deleted operations
-			dispatch_queue(const dispatch_queue& rhs) = delete;
-			dispatch_queue& operator=(const dispatch_queue& rhs) = delete;
-			dispatch_queue(dispatch_queue&& rhs) = delete;
-			dispatch_queue& operator=(dispatch_queue&& rhs) = delete;
+  // Deleted operations
+  dispatch_queue(const dispatch_queue& rhs) = delete;
+  dispatch_queue& operator=(const dispatch_queue& rhs) = delete;
+  dispatch_queue(dispatch_queue&& rhs)                 = delete;
+  dispatch_queue& operator=(dispatch_queue&& rhs) = delete;
 
-			size_t size();
+  size_t size();
 
-	private:
-			std::string m_name;
-			std::mutex m_threads_lock;
-			mutable std::vector<std::thread> m_threads;
-			std::mutex m_mq_mutex;
-			std::queue<dispatch_callback_collection_t> m_mq;
-			std::condition_variable m_cv;
-			bool m_quit = false;
+private:
+  std::string m_name;
+  std::mutex m_threads_lock;
+  mutable std::vector<std::thread> m_threads;
+  std::mutex m_mq_mutex;
+  std::queue<dispatch_callback_collection_t> m_mq;
+  std::condition_variable m_cv;
+  bool m_quit = false;
 
-			notify_callback_t notify_handler;
+  notify_callback_t notify_handler;
 
-			void dispatch_thread_handler();
-	};
+  void dispatch_thread_handler();
+};
 
-	typedef dispatch_queue dispatch_queue_t;
-	typedef std::unique_ptr<dispatch_queue> dispatch_queue_ptr_t;
-}
+typedef dispatch_queue dispatch_queue_t;
+typedef std::unique_ptr<dispatch_queue> dispatch_queue_ptr_t;
+} // namespace cpp_redis
 
 
 #endif //CPP_REDIS_DISPATCH_QUEUE_HPP

--- a/includes/cpp_redis/misc/error.hpp
+++ b/includes/cpp_redis/misc/error.hpp
@@ -36,7 +36,7 @@ public:
   using std::runtime_error::runtime_error;
   using std::runtime_error::what;
 
-/**
+  /**
  * ctor (string)
  *
  */
@@ -44,7 +44,7 @@ public:
   : std::runtime_error(err.c_str()) {
   }
 
-/**
+  /**
  * ctor(char*)
  *
  */

--- a/includes/cpp_redis/misc/logger.hpp
+++ b/includes/cpp_redis/misc/logger.hpp
@@ -35,30 +35,30 @@ namespace cpp_redis {
  */
 class logger_iface {
 public:
-/**
+  /**
  * ctor
  *
  */
   logger_iface() = default;
-/**
+  /**
  * dtor
  *
  */
   virtual ~logger_iface() = default;
 
-/**
+  /**
  * copy ctor
  *
  */
   logger_iface(const logger_iface&) = default;
-/**
+  /**
  * assignment operator
  *
  */
   logger_iface& operator=(const logger_iface&) = default;
 
 public:
-/**
+  /**
  * debug logging
  *
  * @param msg message to be logged
@@ -68,7 +68,7 @@ public:
  */
   virtual void debug(const std::string& msg, const std::string& file, std::size_t line) = 0;
 
-/**
+  /**
  * info logging
  *
  * @param msg message to be logged
@@ -78,7 +78,7 @@ public:
  */
   virtual void info(const std::string& msg, const std::string& file, std::size_t line) = 0;
 
-/**
+  /**
  * warn logging
  *
  * @param msg message to be logged
@@ -88,7 +88,7 @@ public:
  */
   virtual void warn(const std::string& msg, const std::string& file, std::size_t line) = 0;
 
-/**
+  /**
  * error logging
  *
  * @param msg message to be logged
@@ -105,7 +105,7 @@ public:
  */
 class logger : public logger_iface {
 public:
-/**
+  /**
  * log level
  *
  */
@@ -117,30 +117,30 @@ public:
   };
 
 public:
-/**
+  /**
  * ctor
  *
  */
-    explicit logger(log_level level = log_level::info);
-/**
+  explicit logger(log_level level = log_level::info);
+  /**
  * dtor
  *
  */
   ~logger() override = default;
 
-/**
+  /**
  * copy ctor
  *
  */
   logger(const logger&) = default;
-/**
+  /**
  * assignment operator
  *
  */
   logger& operator=(const logger&) = default;
 
 public:
-/**
+  /**
  * debug logging
  *
  * @param msg message to be logged
@@ -150,7 +150,7 @@ public:
  */
   void debug(const std::string& msg, const std::string& file, std::size_t line) override;
 
-/**
+  /**
  * info logging
  *
  * @param msg message to be logged
@@ -160,7 +160,7 @@ public:
  */
   void info(const std::string& msg, const std::string& file, std::size_t line) override;
 
-/**
+  /**
  * warn logging
  *
  * @param msg message to be logged
@@ -170,7 +170,7 @@ public:
  */
   void warn(const std::string& msg, const std::string& file, std::size_t line) override;
 
-/**
+  /**
  * error logging
  *
  * @param msg message to be logged
@@ -181,13 +181,13 @@ public:
   void error(const std::string& msg, const std::string& file, std::size_t line) override;
 
 private:
-/**
+  /**
  * current log level in use
  *
  */
   log_level m_level;
 
-/**
+  /**
  * mutex used to serialize logs in multi-threaded environment
  *
  */

--- a/includes/cpp_redis/misc/optional.hpp
+++ b/includes/cpp_redis/misc/optional.hpp
@@ -44,12 +44,13 @@ using enableIf = typename std::enable_if<I, T>::type;
 
 template <class T>
 struct optional {
-  optional(T value) : m_value(value) {}
-//  optional<T>&
-//  operator()(T value) {
-//    m_value = value;
-//    return *this;
-//  }
+  optional(T value)
+  : m_value(value) {}
+  //  optional<T>&
+  //  operator()(T value) {
+  //    m_value = value;
+  //    return *this;
+  //  }
 
   T m_value;
 

--- a/includes/cpp_redis/misc/optional.hpp
+++ b/includes/cpp_redis/misc/optional.hpp
@@ -56,7 +56,7 @@ struct optional {
   template <class U>
   enableIf<std::is_convertible<U, T>::value, T>
   value_or(U&& v) const {
-    __CPP_REDIS_LOG(1, "value_or(U&& v)\n")
+    __CPP_REDIS_LOG(warn, "value_or(U&& v)\n")
     return std::forward<U>(v);
   }
 

--- a/includes/cpp_redis/network/redis_connection.hpp
+++ b/includes/cpp_redis/network/redis_connection.hpp
@@ -37,64 +37,64 @@
 
 namespace cpp_redis {
 
-	namespace network {
+namespace network {
 
 /**
  * tcp connection wrapper handling redis protocol
  *
  */
-		class redis_connection {
-		public:
+class redis_connection {
+public:
 #ifndef __CPP_REDIS_USE_CUSTOM_TCP_CLIENT
 
-/**
+  /**
  * ctor
  *
  */
-				redis_connection();
+  redis_connection();
 
 #endif /* __CPP_REDIS_USE_CUSTOM_TCP_CLIENT */
 
-/**
+  /**
  * ctor allowing to specify custom tcp client (default ctor uses the default tacopie tcp client)
  *
  * @param tcp_client tcp client to be used for network communications
  *
  */
-				explicit redis_connection(const std::shared_ptr<tcp_client_iface> &tcp_client);
+  explicit redis_connection(const std::shared_ptr<tcp_client_iface>& tcp_client);
 
-/**
+  /**
  * dtor
  *
  */
-				~redis_connection();
+  ~redis_connection();
 
-/**
+  /**
  * copy ctor
  *
  */
-				redis_connection(const redis_connection &) = delete;
+  redis_connection(const redis_connection&) = delete;
 
-/**
+  /**
  * assignment operator
  *
  */
-				redis_connection &operator=(const redis_connection &) = delete;
+  redis_connection& operator=(const redis_connection&) = delete;
 
-		public:
-/**
+public:
+  /**
  * disconnection handler takes as parameter the instance of the redis_connection
  *
  */
-				typedef std::function<void(redis_connection &)> disconnection_handler_t;
+  typedef std::function<void(redis_connection&)> disconnection_handler_t;
 
-/**
+  /**
  * reply handler takes as parameter the instance of the redis_connection and the built reply
  *
  */
-				typedef std::function<void(redis_connection &, reply &)> reply_callback_t;
+  typedef std::function<void(redis_connection&, reply&)> reply_callback_t;
 
-/**
+  /**
  * connect to the given host and port, and set both disconnection and reply callbacks
  *
  * @param host host to be connected to
@@ -104,28 +104,28 @@ namespace cpp_redis {
  * @param timeout_ms max time to connect (in ms)
  *
  */
-				void connect(
-						const std::string &host = "127.0.0.1",
-						std::size_t port = 6379,
-						const disconnection_handler_t &disconnection_handler = nullptr,
-						const reply_callback_t &reply_callback = nullptr,
-						std::uint32_t timeout_ms = 0);
+  void connect(
+    const std::string& host                              = "127.0.0.1",
+    std::size_t port                                     = 6379,
+    const disconnection_handler_t& disconnection_handler = nullptr,
+    const reply_callback_t& reply_callback               = nullptr,
+    std::uint32_t timeout_ms                             = 0);
 
-/**
+  /**
  * disconnect from redis server
  *
  * @param wait_for_removal when sets to true, disconnect blocks until the underlying TCP client has been effectively removed from the io_service and that all the underlying callbacks have completed.
  *
  */
-				void disconnect(bool wait_for_removal = false);
+  void disconnect(bool wait_for_removal = false);
 
-/**
+  /**
  * @return whether we are connected to the redis server or not
  *
  */
-				bool is_connected() const;
+  bool is_connected() const;
 
-/**
+  /**
  * send the given command
  * the command is actually pipelined and only buffered, so nothing is sent to the network
  * please call commit() to flush the buffer
@@ -134,86 +134,86 @@ namespace cpp_redis {
  * @return current instance
  *
  */
-				redis_connection &send(const std::vector<std::string> &redis_cmd);
+  redis_connection& send(const std::vector<std::string>& redis_cmd);
 
-/**
+  /**
  * commit pipelined transaction
  * that is, send to the network all commands pipelined by calling send()
  *
  * @return current instance
  *
  */
-				redis_connection &commit();
+  redis_connection& commit();
 
-		private:
-/**
+private:
+  /**
  * tcp_client receive handler
  * called by the tcp_client whenever a read has completed
  *
  * @param result read result
  *
  */
-				void tcp_client_receive_handler(const tcp_client_iface::read_result &result);
+  void tcp_client_receive_handler(const tcp_client_iface::read_result& result);
 
-/**
+  /**
  * tcp_client disconnection handler
  * called by the tcp_client whenever a disconnection occurred
  *
  */
-				void tcp_client_disconnection_handler();
+  void tcp_client_disconnection_handler();
 
-/**
+  /**
  * transform a user command to a redis command using the redis protocol format
  * for example, transform {"GET", "HELLO"} to something like "*2\r\n+GET\r\n+HELLO\r\n"
  *
  */
-				std::string build_command(const std::vector<std::string> &redis_cmd);
+  std::string build_command(const std::vector<std::string>& redis_cmd);
 
-		private:
-/**
+private:
+  /**
  * simply call the disconnection handler (does nothing if disconnection handler is set to null)
  *
  */
-				void call_disconnection_handler();
+  void call_disconnection_handler();
 
-		private:
-/**
+private:
+  /**
  * tcp client for redis connection
  *
  */
-				std::shared_ptr<cpp_redis::network::tcp_client_iface> m_client;
+  std::shared_ptr<cpp_redis::network::tcp_client_iface> m_client;
 
-/**
+  /**
  * reply callback called whenever a reply has been read
  *
  */
-				reply_callback_t m_reply_callback;
+  reply_callback_t m_reply_callback;
 
-/**
+  /**
  * disconnection handler whenever a disconnection occurred
  *
  */
-				disconnection_handler_t m_disconnection_handler;
+  disconnection_handler_t m_disconnection_handler;
 
-/**
+  /**
  * reply builder used to build replies
  *
  */
-				builders::reply_builder m_builder;
+  builders::reply_builder m_builder;
 
-/**
+  /**
  * internal buffer used for pipelining (commands are buffered here and flushed to the tcp client when commit is called)
  *
  */
-				std::string m_buffer;
+  std::string m_buffer;
 
-/**
+  /**
  * protect internal buffer against race conditions
  *
  */
-				std::mutex m_buffer_mutex;
-		};
+  std::mutex m_buffer_mutex;
+};
 
-	} // namespace network
+} // namespace network
 
 } // namespace cpp_redis

--- a/includes/cpp_redis/network/tcp_client.hpp
+++ b/includes/cpp_redis/network/tcp_client.hpp
@@ -37,19 +37,19 @@ namespace network {
  */
 class tcp_client : public tcp_client_iface {
 public:
-/**
+  /**
  * ctor
  *
  */
   tcp_client() = default;
-/**
+  /**
  * dtor
  *
  */
   ~tcp_client() override = default;
 
 public:
-/**
+  /**
  * start the tcp client
  *
  * @param addr host to be connected to
@@ -59,7 +59,7 @@ public:
  */
   void connect(const std::string& addr, std::uint32_t port, std::uint32_t timeout_ms) override;
 
-/**
+  /**
  * stop the tcp client
  *
  * @param wait_for_removal when sets to true, disconnect blocks until the underlying TCP client has been effectively removed from the io_service and that all the underlying callbacks have completed.
@@ -67,13 +67,13 @@ public:
  */
   void disconnect(bool wait_for_removal = false) override;
 
-/**
+  /**
  * @return whether the client is currently connected or not
  *
  */
   bool is_connected() const override;
 
-/**
+  /**
  * set number of io service workers for the io service monitoring this tcp connection
  *
  * @param nb_threads number of threads to be assigned
@@ -82,7 +82,7 @@ public:
   void set_nb_workers(std::size_t nb_threads);
 
 public:
-/**
+  /**
  * async read operation
  *
  * @param request information about what should be read and what should be done after completion
@@ -90,7 +90,7 @@ public:
  */
   void async_read(read_request& request) override;
 
-/**
+  /**
  * async write operation
  *
  * @param request information about what should be written and what should be done after completion
@@ -99,7 +99,7 @@ public:
   void async_write(write_request& request) override;
 
 public:
-/**
+  /**
  * set on disconnection handler
  *
  * @param disconnection_handler handler to be called in case of a disconnection
@@ -108,7 +108,7 @@ public:
   void set_on_disconnection_handler(const disconnection_handler_t& disconnection_handler) override;
 
 private:
-/**
+  /**
  * tcp client for redis connection
  *
  */

--- a/includes/cpp_redis/network/tcp_client_iface.hpp
+++ b/includes/cpp_redis/network/tcp_client_iface.hpp
@@ -37,19 +37,19 @@ namespace network {
  */
 class tcp_client_iface {
 public:
-/**
+  /**
  * ctor
  *
  */
   tcp_client_iface() = default;
-/**
+  /**
  * dtor
  *
  */
   virtual ~tcp_client_iface() = default;
 
 public:
-/**
+  /**
  * start the tcp client
  *
  * @param addr host to be connected to
@@ -59,7 +59,7 @@ public:
  */
   virtual void connect(const std::string& addr, std::uint32_t port, std::uint32_t timeout_ms = 0) = 0;
 
-/**
+  /**
  * stop the tcp client
  *
  * @param wait_for_removal when sets to true, disconnect blocks until the underlying TCP client has been effectively removed from the io_service and that all the underlying callbacks have completed.
@@ -67,43 +67,43 @@ public:
  */
   virtual void disconnect(bool wait_for_removal = false) = 0;
 
-/**
+  /**
  * @return whether the client is currently connected or not
  *
  */
   virtual bool is_connected() const = 0;
 
 public:
-/**
+  /**
  * structure to store read requests result
  *
  */
   struct read_result {
-/**
+    /**
  * whether the operation succeeded or not
  *
  */
     bool success;
 
-/**
+    /**
  * read bytes
  *
  */
     std::vector<char> buffer;
   };
 
-/**
+  /**
  * structure to store write requests result
  *
  */
   struct write_result {
-/**
+    /**
  * whether the operation succeeded or not
  *
  */
     bool success;
 
-/**
+    /**
  * number of bytes written
  *
  */
@@ -111,14 +111,14 @@ public:
   };
 
 public:
-/**
+  /**
  * async read completion callbacks
  * function taking read_result as a parameter
  *
  */
   typedef std::function<void(read_result&)> async_read_callback_t;
 
-/**
+  /**
  * async write completion callbacks
  * function taking write_result as a parameter
  *
@@ -126,36 +126,36 @@ public:
   typedef std::function<void(write_result&)> async_write_callback_t;
 
 public:
-/**
+  /**
  * structure to store read requests information
  *
  */
   struct read_request {
-/**
+    /**
  * number of bytes to read
  *
  */
     std::size_t size;
 
-/**
+    /**
  * callback to be called on operation completion
  *
  */
     async_read_callback_t async_read_callback;
   };
 
-/**
+  /**
  * structure to store write requests information
  *
  */
   struct write_request {
-/**
+    /**
  * bytes to write
  *
  */
     std::vector<char> buffer;
 
-/**
+    /**
  * callback to be called on operation completion
  *
  */
@@ -163,7 +163,7 @@ public:
   };
 
 public:
-/**
+  /**
  * async read operation
  *
  * @param request information about what should be read and what should be done after completion
@@ -171,7 +171,7 @@ public:
  */
   virtual void async_read(read_request& request) = 0;
 
-/**
+  /**
  * async write operation
  *
  * @param request information about what should be written and what should be done after completion
@@ -180,13 +180,13 @@ public:
   virtual void async_write(write_request& request) = 0;
 
 public:
-/**
+  /**
  * disconnection handler
  *
  */
   typedef std::function<void()> disconnection_handler_t;
 
-/**
+  /**
  * set on disconnection handler
  *
  * @param disconnection_handler handler to be called in case of a disconnection

--- a/sources/builders/reply_builder.cpp
+++ b/sources/builders/reply_builder.cpp
@@ -26,74 +26,75 @@
 
 namespace cpp_redis {
 
-	namespace builders {
+namespace builders {
 
-		reply_builder::reply_builder()
-				: m_builder(nullptr) {}
+reply_builder::reply_builder()
+: m_builder(nullptr) {}
 
-		reply_builder &
-		reply_builder::operator<<(const std::string &data) {
-			m_buffer += data;
+reply_builder&
+reply_builder::operator<<(const std::string& data) {
+  m_buffer += data;
 
-			while (build_reply());
+  while (build_reply())
+    ;
 
-			return *this;
-		}
+  return *this;
+}
 
-		void
-		reply_builder::reset() {
-			m_builder = nullptr;
-			m_buffer.clear();
-		}
+void
+reply_builder::reset() {
+  m_builder = nullptr;
+  m_buffer.clear();
+}
 
-		bool
-		reply_builder::build_reply() {
-			if (m_buffer.empty())
-				return false;
+bool
+reply_builder::build_reply() {
+  if (m_buffer.empty())
+    return false;
 
-			if (!m_builder) {
-				m_builder = create_builder(m_buffer.front());
-				m_buffer.erase(0, 1);
-			}
+  if (!m_builder) {
+    m_builder = create_builder(m_buffer.front());
+    m_buffer.erase(0, 1);
+  }
 
-			*m_builder << m_buffer;
+  *m_builder << m_buffer;
 
-			if (m_builder->reply_ready()) {
-				m_available_replies.push_back(m_builder->get_reply());
-				m_builder = nullptr;
+  if (m_builder->reply_ready()) {
+    m_available_replies.push_back(m_builder->get_reply());
+    m_builder = nullptr;
 
-				return true;
-			}
+    return true;
+  }
 
-			return false;
-		}
+  return false;
+}
 
-		void
-		reply_builder::operator>>(reply &reply) {
-			reply = get_front();
-		}
+void
+reply_builder::operator>>(reply& reply) {
+  reply = get_front();
+}
 
-		const reply &
-		reply_builder::get_front() const {
-			if (!reply_available())
-				throw redis_error("No available reply");
+const reply&
+reply_builder::get_front() const {
+  if (!reply_available())
+    throw redis_error("No available reply");
 
-			return m_available_replies.front();
-		}
+  return m_available_replies.front();
+}
 
-		void
-		reply_builder::pop_front() {
-			if (!reply_available())
-				throw redis_error("No available reply");
+void
+reply_builder::pop_front() {
+  if (!reply_available())
+    throw redis_error("No available reply");
 
-			m_available_replies.pop_front();
-		}
+  m_available_replies.pop_front();
+}
 
-		bool
-		reply_builder::reply_available() const {
-			return !m_available_replies.empty();
-		}
+bool
+reply_builder::reply_available() const {
+  return !m_available_replies.empty();
+}
 
-	} // namespace builders
+} // namespace builders
 
 } // namespace cpp_redis

--- a/sources/core/client.cpp
+++ b/sources/core/client.cpp
@@ -28,2453 +28,2456 @@ namespace cpp_redis {
 
 #ifndef __CPP_REDIS_USE_CUSTOM_TCP_CLIENT
 
-	client::client()
-			: m_reconnecting(false), m_cancel(false), m_callbacks_running(0) {
-		__CPP_REDIS_LOG(debug, "cpp_redis::client created");
-	}
+client::client()
+: m_reconnecting(false), m_cancel(false), m_callbacks_running(0) {
+  __CPP_REDIS_LOG(debug, "cpp_redis::client created");
+}
 
 #endif /* __CPP_REDIS_USE_CUSTOM_TCP_CLIENT */
 
-	client::client(const std::shared_ptr<network::tcp_client_iface> &tcp_client)
-			: m_client(tcp_client), m_sentinel(tcp_client), m_reconnecting(false), m_cancel(false), m_callbacks_running(0) {
-		__CPP_REDIS_LOG(debug, "cpp_redis::client created");
-	}
+client::client(const std::shared_ptr<network::tcp_client_iface>& tcp_client)
+: m_client(tcp_client), m_sentinel(tcp_client), m_reconnecting(false), m_cancel(false), m_callbacks_running(0) {
+  __CPP_REDIS_LOG(debug, "cpp_redis::client created");
+}
 
-	client::~client() {
-/**
+client::~client() {
+  /**
  * ensure we stopped reconnection attempts
  */
-		if (!m_cancel) {
-			cancel_reconnect();
-		}
+  if (!m_cancel) {
+    cancel_reconnect();
+  }
 
-/**
+  /**
  * If for some reason sentinel is connected then disconnect now.
  */
-		if (m_sentinel.is_connected()) {
-			m_sentinel.disconnect(true);
-		}
+  if (m_sentinel.is_connected()) {
+    m_sentinel.disconnect(true);
+  }
 
-/**
+  /**
  * disconnect underlying tcp socket
  */
-		if (m_client.is_connected()) {
-			m_client.disconnect(true);
-		}
+  if (m_client.is_connected()) {
+    m_client.disconnect(true);
+  }
 
-		__CPP_REDIS_LOG(debug, "cpp_redis::client destroyed");
-	}
+  __CPP_REDIS_LOG(debug, "cpp_redis::client destroyed");
+}
 
-	void
-	client::connect(
-			const std::string &name,
-			const connect_callback_t &connect_callback,
-			std::uint32_t timeout_ms,
-			std::int32_t max_reconnects,
-			std::uint32_t reconnect_interval_ms) {
-/**
+void
+client::connect(
+  const std::string& name,
+  const connect_callback_t& connect_callback,
+  std::uint32_t timeout_ms,
+  std::int32_t max_reconnects,
+  std::uint32_t reconnect_interval_ms) {
+  /**
  * Save for auto reconnects
  */
-		m_master_name = name;
+  m_master_name = name;
 
-/**
+  /**
  * We rely on the sentinel to tell us which redis server is currently the master.
  */
-		if (m_sentinel.get_master_addr_by_name(name, m_redis_server, m_redis_port, true)) {
-			connect(m_redis_server, m_redis_port, connect_callback, timeout_ms, max_reconnects, reconnect_interval_ms);
-		} else {
-			throw redis_error("cpp_redis::client::connect() could not find master for m_name " + name);
-		}
-	}
+  if (m_sentinel.get_master_addr_by_name(name, m_redis_server, m_redis_port, true)) {
+    connect(m_redis_server, m_redis_port, connect_callback, timeout_ms, max_reconnects, reconnect_interval_ms);
+  }
+  else {
+    throw redis_error("cpp_redis::client::connect() could not find master for m_name " + name);
+  }
+}
 
 
-	void
-	client::connect(
-			const std::string &host, std::size_t port,
-			const connect_callback_t &connect_callback,
-			std::uint32_t timeout_ms,
-			std::int32_t max_reconnects,
-			std::uint32_t reconnect_interval_ms) {
-		__CPP_REDIS_LOG(debug, "cpp_redis::client attempts to connect");
+void
+client::connect(
+  const std::string& host, std::size_t port,
+  const connect_callback_t& connect_callback,
+  std::uint32_t timeout_ms,
+  std::int32_t max_reconnects,
+  std::uint32_t reconnect_interval_ms) {
+  __CPP_REDIS_LOG(debug, "cpp_redis::client attempts to connect");
 
-/**
+  /**
  * Save for auto reconnects
  */
-		m_redis_server = host;
-		m_redis_port = port;
-		m_connect_callback = connect_callback;
-		m_max_reconnects = max_reconnects;
-		m_reconnect_interval_ms = reconnect_interval_ms;
+  m_redis_server          = host;
+  m_redis_port            = port;
+  m_connect_callback      = connect_callback;
+  m_max_reconnects        = max_reconnects;
+  m_reconnect_interval_ms = reconnect_interval_ms;
 
-/**
+  /**
  * notify start
  */
-		if (m_connect_callback) {
-			m_connect_callback(host, port, connect_state::start);
-		}
+  if (m_connect_callback) {
+    m_connect_callback(host, port, connect_state::start);
+  }
 
-		auto disconnection_handler = std::bind(&client::connection_disconnection_handler, this, std::placeholders::_1);
-		auto receive_handler = std::bind(&client::connection_receive_handler, this, std::placeholders::_1,
-		                                 std::placeholders::_2);
-		m_client.connect(host, port, disconnection_handler, receive_handler, timeout_ms);
+  auto disconnection_handler = std::bind(&client::connection_disconnection_handler, this, std::placeholders::_1);
+  auto receive_handler       = std::bind(&client::connection_receive_handler, this, std::placeholders::_1,
+    std::placeholders::_2);
+  m_client.connect(host, port, disconnection_handler, receive_handler, timeout_ms);
 
-		__CPP_REDIS_LOG(info, "cpp_redis::client connected");
+  __CPP_REDIS_LOG(info, "cpp_redis::client connected");
 
-/**
+  /**
  * notify end
  */
-		if (m_connect_callback) {
-			m_connect_callback(m_redis_server, m_redis_port, connect_state::ok);
-		}
-	}
+  if (m_connect_callback) {
+    m_connect_callback(m_redis_server, m_redis_port, connect_state::ok);
+  }
+}
 
-	void
-	client::disconnect(bool wait_for_removal) {
-		__CPP_REDIS_LOG(debug, "cpp_redis::client attempts to disconnect");
+void
+client::disconnect(bool wait_for_removal) {
+  __CPP_REDIS_LOG(debug, "cpp_redis::client attempts to disconnect");
 
-/**
+  /**
  * close connection
  */
-		m_client.disconnect(wait_for_removal);
+  m_client.disconnect(wait_for_removal);
 
-/**
+  /**
  * make sure we clear buffer of unsent commands
  */
-		clear_callbacks();
+  clear_callbacks();
 
-		__CPP_REDIS_LOG(info, "cpp_redis::client disconnected");
-	}
+  __CPP_REDIS_LOG(info, "cpp_redis::client disconnected");
+}
 
-	bool
-	client::is_connected() const {
-		return m_client.is_connected();
-	}
+bool
+client::is_connected() const {
+  return m_client.is_connected();
+}
 
-	void
-	client::cancel_reconnect() {
-		m_cancel = true;
-	}
+void
+client::cancel_reconnect() {
+  m_cancel = true;
+}
 
-	bool
-	client::is_reconnecting() const {
-		return m_reconnecting;
-	}
+bool
+client::is_reconnecting() const {
+  return m_reconnecting;
+}
 
-	void
-	client::add_sentinel(const std::string &host, std::size_t port, std::uint32_t timeout_ms) {
-		m_sentinel.add_sentinel(host, port, timeout_ms);
-	}
+void
+client::add_sentinel(const std::string& host, std::size_t port, std::uint32_t timeout_ms) {
+  m_sentinel.add_sentinel(host, port, timeout_ms);
+}
 
-	const sentinel &
-	client::get_sentinel() const {
-		return m_sentinel;
-	}
+const sentinel&
+client::get_sentinel() const {
+  return m_sentinel;
+}
 
-	sentinel &
-	client::get_sentinel() {
-		return m_sentinel;
-	}
+sentinel&
+client::get_sentinel() {
+  return m_sentinel;
+}
 
-	void
-	client::clear_sentinels() {
-		m_sentinel.clear_sentinels();
-	}
+void
+client::clear_sentinels() {
+  m_sentinel.clear_sentinels();
+}
 
-	client &
-	client::send(const std::vector<std::string> &redis_cmd, const reply_callback_t &callback) {
-		std::lock_guard<std::mutex> lock_callback(m_callbacks_mutex);
+client&
+client::send(const std::vector<std::string>& redis_cmd, const reply_callback_t& callback) {
+  std::lock_guard<std::mutex> lock_callback(m_callbacks_mutex);
 
-		__CPP_REDIS_LOG(info, "cpp_redis::client attempts to store new command in the send buffer");
-		unprotected_send(redis_cmd, callback);
-		__CPP_REDIS_LOG(info, "cpp_redis::client stored new command in the send buffer");
+  __CPP_REDIS_LOG(info, "cpp_redis::client attempts to store new command in the send buffer");
+  unprotected_send(redis_cmd, callback);
+  __CPP_REDIS_LOG(info, "cpp_redis::client stored new command in the send buffer");
 
-		return *this;
-	}
+  return *this;
+}
 
-	void
-	client::unprotected_send(const std::vector<std::string> &redis_cmd, const reply_callback_t &callback) {
-		m_client.send(redis_cmd);
-		m_commands.push({redis_cmd, callback});
-	}
+void
+client::unprotected_send(const std::vector<std::string>& redis_cmd, const reply_callback_t& callback) {
+  m_client.send(redis_cmd);
+  m_commands.push({redis_cmd, callback});
+}
 
 /**
  * commit pipelined transaction
  */
-	client &
-	client::commit() {
-/**
+client&
+client::commit() {
+  /**
  * no need to call commit in case of reconnection
  * the reconnection flow will do it for us
  */
-		if (!is_reconnecting()) {
-			try_commit();
-		}
+  if (!is_reconnecting()) {
+    try_commit();
+  }
 
-		return *this;
-	}
+  return *this;
+}
 
-	client &
-	client::sync_commit() {
-/**
+client&
+client::sync_commit() {
+  /**
  * no need to call commit in case of reconnection
  * the reconnection flow will do it for us
  */
-		if (!is_reconnecting()) {
-			try_commit();
-		}
+  if (!is_reconnecting()) {
+    try_commit();
+  }
 
-		std::unique_lock<std::mutex> lock_callback(m_callbacks_mutex);
-		__CPP_REDIS_LOG(debug, "cpp_redis::client waiting for callbacks to complete");
-		m_sync_condvar.wait(lock_callback, [=] { return m_callbacks_running == 0 && m_commands.empty(); });
-		__CPP_REDIS_LOG(debug, "cpp_redis::client finished waiting for callback completion");
-		return *this;
-	}
+  std::unique_lock<std::mutex> lock_callback(m_callbacks_mutex);
+  __CPP_REDIS_LOG(debug, "cpp_redis::client waiting for callbacks to complete");
+  m_sync_condvar.wait(lock_callback, [=] { return m_callbacks_running == 0 && m_commands.empty(); });
+  __CPP_REDIS_LOG(debug, "cpp_redis::client finished waiting for callback completion");
+  return *this;
+}
 
-	void
-	client::try_commit() {
-		try {
-			__CPP_REDIS_LOG(debug, "cpp_redis::client attempts to send pipelined commands");
-			m_client.commit();
-			__CPP_REDIS_LOG(info, "cpp_redis::client sent pipelined commands");
-		}
-		catch (const cpp_redis::redis_error &) {
-			__CPP_REDIS_LOG(error, "cpp_redis::client could not send pipelined commands");
-			/**
+void
+client::try_commit() {
+  try {
+    __CPP_REDIS_LOG(debug, "cpp_redis::client attempts to send pipelined commands");
+    m_client.commit();
+    __CPP_REDIS_LOG(info, "cpp_redis::client sent pipelined commands");
+  }
+  catch (const cpp_redis::redis_error&) {
+    __CPP_REDIS_LOG(error, "cpp_redis::client could not send pipelined commands");
+    /**
 			 * ensure commands are flushed
 			 */
-			clear_callbacks();
-			throw;
-		}
-	}
+    clear_callbacks();
+    throw;
+  }
+}
 
-	void
-	client::connection_receive_handler(network::redis_connection &, reply &reply) {
-		reply_callback_t callback = nullptr;
+void
+client::connection_receive_handler(network::redis_connection&, reply& reply) {
+  reply_callback_t callback = nullptr;
 
-		__CPP_REDIS_LOG(info, "cpp_redis::client received reply");
-		{
-			std::lock_guard<std::mutex> lock(m_callbacks_mutex);
-			m_callbacks_running += 1;
+  __CPP_REDIS_LOG(info, "cpp_redis::client received reply");
+  {
+    std::lock_guard<std::mutex> lock(m_callbacks_mutex);
+    m_callbacks_running += 1;
 
-			if (!m_commands.empty()) {
-				callback = m_commands.front().callback;
-				m_commands.pop();
-			}
-		}
+    if (!m_commands.empty()) {
+      callback = m_commands.front().callback;
+      m_commands.pop();
+    }
+  }
 
-		if (callback) {
-			__CPP_REDIS_LOG(debug, "cpp_redis::client executes reply callback");
-			callback(reply);
-		}
+  if (callback) {
+    __CPP_REDIS_LOG(debug, "cpp_redis::client executes reply callback");
+    callback(reply);
+  }
 
-		{
-			std::lock_guard<std::mutex> lock(m_callbacks_mutex);
-			m_callbacks_running -= 1;
-			m_sync_condvar.notify_all();
-		}
-	}
+  {
+    std::lock_guard<std::mutex> lock(m_callbacks_mutex);
+    m_callbacks_running -= 1;
+    m_sync_condvar.notify_all();
+  }
+}
 
-	void
-	client::clear_callbacks() {
-		if (m_commands.empty()) {
-			return;
-		}
+void
+client::clear_callbacks() {
+  if (m_commands.empty()) {
+    return;
+  }
 
-/**
+  /**
  * dequeue commands and move them to a local variable
  */
-		std::queue<command_request> commands = std::move(m_commands);
+  std::queue<command_request> commands = std::move(m_commands);
 
-		m_callbacks_running += __CPP_REDIS_LENGTH(commands.size());
+  m_callbacks_running += __CPP_REDIS_LENGTH(commands.size());
 
-		std::thread t([=]() mutable {
-				while (!commands.empty()) {
-					const auto &callback = commands.front().callback;
+  std::thread t([=]() mutable {
+    while (!commands.empty()) {
+      const auto& callback = commands.front().callback;
 
-					if (callback) {
-						reply r = {"network failure", reply::string_type::error};
-						callback(r);
-					}
+      if (callback) {
+        reply r = {"network failure", reply::string_type::error};
+        callback(r);
+      }
 
-					--m_callbacks_running;
-					commands.pop();
-				}
+      --m_callbacks_running;
+      commands.pop();
+    }
 
-				m_sync_condvar.notify_all();
-		});
-		t.detach();
-	}
+    m_sync_condvar.notify_all();
+  });
+  t.detach();
+}
 
-	void
-	client::resend_failed_commands() {
-		if (m_commands.empty()) {
-			return;
-		}
+void
+client::resend_failed_commands() {
+  if (m_commands.empty()) {
+    return;
+  }
 
-/**
+  /**
  * dequeue commands and move them to a local variable
  */
-		std::queue<command_request> commands = std::move(m_commands);
+  std::queue<command_request> commands = std::move(m_commands);
 
-		while (!commands.empty()) {
-/**
+  while (!commands.empty()) {
+    /**
  * Reissue the pending command and its callback.
  */
-			unprotected_send(commands.front().command, commands.front().callback);
+    unprotected_send(commands.front().command, commands.front().callback);
 
-			commands.pop();
-		}
-	}
+    commands.pop();
+  }
+}
 
-	void
-	client::connection_disconnection_handler(network::redis_connection &) {
-/**
+void
+client::connection_disconnection_handler(network::redis_connection&) {
+  /**
  * leave right now if we are already dealing with reconnection
  */
-		if (is_reconnecting()) {
-			return;
-		}
+  if (is_reconnecting()) {
+    return;
+  }
 
-/**
+  /**
  * initiate reconnection process
  */
-		m_reconnecting = true;
-		m_current_reconnect_attempts = 0;
+  m_reconnecting               = true;
+  m_current_reconnect_attempts = 0;
 
-		__CPP_REDIS_LOG(warn, "cpp_redis::client has been disconnected");
+  __CPP_REDIS_LOG(warn, "cpp_redis::client has been disconnected");
 
-		if (m_connect_callback) {
-			m_connect_callback(m_redis_server, m_redis_port, connect_state::dropped);
-		}
+  if (m_connect_callback) {
+    m_connect_callback(m_redis_server, m_redis_port, connect_state::dropped);
+  }
 
-/**
+  /**
  * Lock the callbacks mutex of the base class to prevent more client commands from being issued until our reconnect has completed.
  */
-		std::lock_guard<std::mutex> lock_callback(m_callbacks_mutex);
+  std::lock_guard<std::mutex> lock_callback(m_callbacks_mutex);
 
-		while (should_reconnect()) {
-			sleep_before_next_reconnect_attempt();
-			reconnect();
-		}
+  while (should_reconnect()) {
+    sleep_before_next_reconnect_attempt();
+    reconnect();
+  }
 
-		if (!is_connected()) {
-			clear_callbacks();
+  if (!is_connected()) {
+    clear_callbacks();
 
-/**
+    /**
  * Tell the user we gave up!
  */
-			if (m_connect_callback) {
-				m_connect_callback(m_redis_server, m_redis_port, connect_state::stopped);
-			}
-		}
+    if (m_connect_callback) {
+      m_connect_callback(m_redis_server, m_redis_port, connect_state::stopped);
+    }
+  }
 
-/**
+  /**
  * terminate reconnection
  */
-		m_reconnecting = false;
-	}
+  m_reconnecting = false;
+}
 
-	void
-	client::sleep_before_next_reconnect_attempt() {
-		if (m_reconnect_interval_ms <= 0) {
-			return;
-		}
+void
+client::sleep_before_next_reconnect_attempt() {
+  if (m_reconnect_interval_ms <= 0) {
+    return;
+  }
 
-		if (m_connect_callback) {
-			m_connect_callback(m_redis_server, m_redis_port, connect_state::sleeping);
-		}
+  if (m_connect_callback) {
+    m_connect_callback(m_redis_server, m_redis_port, connect_state::sleeping);
+  }
 
-		std::this_thread::sleep_for(std::chrono::milliseconds(m_reconnect_interval_ms));
-	}
+  std::this_thread::sleep_for(std::chrono::milliseconds(m_reconnect_interval_ms));
+}
 
-	bool
-	client::should_reconnect() const {
-		return !is_connected() && !m_cancel && (m_max_reconnects == -1 || m_current_reconnect_attempts < m_max_reconnects);
-	}
+bool
+client::should_reconnect() const {
+  return !is_connected() && !m_cancel && (m_max_reconnects == -1 || m_current_reconnect_attempts < m_max_reconnects);
+}
 
-	void
-	client::re_auth() {
-		if (m_password.empty()) {
-			return;
-		}
+void
+client::re_auth() {
+  if (m_password.empty()) {
+    return;
+  }
 
-		// In re_auth we do not want to serialize the command to the TCP buffer (i.e. call m_client.send)
-		// as it will get serialized to the buffer in resend_failed_commands after re_auth is called in
-		// reconnect.  So we just push the command into the command queue.
-		//
-		// Otherwise we will end up with the AUTH command serialized to
-		// the buffer twice and in the command queue once, which causes a problem when we get 2 responses
-		// back.  The subsequent responses are off by one in the command callbacks.
-		//
-		m_commands.push({{"AUTH", m_password}, [&](cpp_redis::reply &reply) {
-				if (reply.is_string() && reply.as_string() == "OK") {
-					__CPP_REDIS_LOG(warn, "client successfully re-authenticated");
-				} else {
-					__CPP_REDIS_LOG(warn, std::string("client failed to re-authenticate: " + reply.as_string()).c_str());
-				}
-		}});
-	}
+  // In re_auth we do not want to serialize the command to the TCP buffer (i.e. call m_client.send)
+  // as it will get serialized to the buffer in resend_failed_commands after re_auth is called in
+  // reconnect.  So we just push the command into the command queue.
+  //
+  // Otherwise we will end up with the AUTH command serialized to
+  // the buffer twice and in the command queue once, which causes a problem when we get 2 responses
+  // back.  The subsequent responses are off by one in the command callbacks.
+  //
+  m_commands.push({{"AUTH", m_password}, [&](cpp_redis::reply& reply) {
+                     if (reply.is_string() && reply.as_string() == "OK") {
+                       __CPP_REDIS_LOG(warn, "client successfully re-authenticated");
+                     }
+                     else {
+                       __CPP_REDIS_LOG(warn, std::string("client failed to re-authenticate: " + reply.as_string()).c_str());
+                     }
+                   }});
+}
 
-	void
-	client::re_select() {
-		if (m_database_index <= 0) {
-			return;
-		}
+void
+client::re_select() {
+  if (m_database_index <= 0) {
+    return;
+  }
 
-		unprotected_select(m_database_index, [&](cpp_redis::reply &reply) {
-				if (reply.is_string() && reply.as_string() == "OK") {
-					__CPP_REDIS_LOG(warn, "client successfully re-selected redis database");
-				} else {
-					__CPP_REDIS_LOG(warn, std::string("client failed to re-select database: " + reply.as_string()).c_str());
-				}
-		});
-	}
+  unprotected_select(m_database_index, [&](cpp_redis::reply& reply) {
+    if (reply.is_string() && reply.as_string() == "OK") {
+      __CPP_REDIS_LOG(warn, "client successfully re-selected redis database");
+    }
+    else {
+      __CPP_REDIS_LOG(warn, std::string("client failed to re-select database: " + reply.as_string()).c_str());
+    }
+  });
+}
 
-	void
-	client::reconnect() {
-/**
+void
+client::reconnect() {
+  /**
  * increase the number of attempts to reconnect
  */
-		++m_current_reconnect_attempts;
+  ++m_current_reconnect_attempts;
 
 
-/**
+  /**
  * We rely on the sentinel to tell us which redis server is currently the master.
  */
-		if (!m_master_name.empty() &&
-		    !m_sentinel.get_master_addr_by_name(m_master_name, m_redis_server, m_redis_port, true)) {
-			if (m_connect_callback) {
-				m_connect_callback(m_redis_server, m_redis_port, connect_state::lookup_failed);
-			}
-			return;
-		}
+  if (!m_master_name.empty() && !m_sentinel.get_master_addr_by_name(m_master_name, m_redis_server, m_redis_port, true)) {
+    if (m_connect_callback) {
+      m_connect_callback(m_redis_server, m_redis_port, connect_state::lookup_failed);
+    }
+    return;
+  }
 
-/**
+  /**
  * Try catch block because the redis client throws an error if connection cannot be made.
  */
-		try {
-			connect(m_redis_server, m_redis_port, m_connect_callback, m_connect_timeout_ms, m_max_reconnects,
-			        m_reconnect_interval_ms);
-		}
-		catch (...) {
-		}
+  try {
+    connect(m_redis_server, m_redis_port, m_connect_callback, m_connect_timeout_ms, m_max_reconnects,
+      m_reconnect_interval_ms);
+  }
+  catch (...) {
+  }
 
-		if (!is_connected()) {
-			if (m_connect_callback) {
-				m_connect_callback(m_redis_server, m_redis_port, connect_state::failed);
-			}
-			return;
-		}
+  if (!is_connected()) {
+    if (m_connect_callback) {
+      m_connect_callback(m_redis_server, m_redis_port, connect_state::failed);
+    }
+    return;
+  }
 
-/**
+  /**
  * notify end
  */
-		if (m_connect_callback) {
-			m_connect_callback(m_redis_server, m_redis_port, connect_state::ok);
-		}
+  if (m_connect_callback) {
+    m_connect_callback(m_redis_server, m_redis_port, connect_state::ok);
+  }
 
-		__CPP_REDIS_LOG(info, "client reconnected ok");
+  __CPP_REDIS_LOG(info, "client reconnected ok");
 
-		re_auth();
-		re_select();
-		resend_failed_commands();
-		try_commit();
-	}
+  re_auth();
+  re_select();
+  resend_failed_commands();
+  try_commit();
+}
 
-	std::string
-	client::aggregate_method_to_string(aggregate_method method) const {
-		switch (method) {
-			case aggregate_method::sum:
-				return "SUM";
-			case aggregate_method::min:
-				return "MIN";
-			case aggregate_method::max:
-				return "MAX";
-			default:
-				return "";
-		}
-	}
+std::string
+client::aggregate_method_to_string(aggregate_method method) const {
+  switch (method) {
+  case aggregate_method::sum:
+    return "SUM";
+  case aggregate_method::min:
+    return "MIN";
+  case aggregate_method::max:
+    return "MAX";
+  default:
+    return "";
+  }
+}
 
-	std::string
-	client::geo_unit_to_string(geo_unit unit) const {
-		switch (unit) {
-			case geo_unit::m:
-				return "m";
-			case geo_unit::km:
-				return "km";
-			case geo_unit::ft:
-				return "ft";
-			case geo_unit::mi:
-				return "mi";
-			default:
-				return "";
-		}
-	}
+std::string
+client::geo_unit_to_string(geo_unit unit) const {
+  switch (unit) {
+  case geo_unit::m:
+    return "m";
+  case geo_unit::km:
+    return "km";
+  case geo_unit::ft:
+    return "ft";
+  case geo_unit::mi:
+    return "mi";
+  default:
+    return "";
+  }
+}
 
-	std::string
-	client::bitfield_operation_type_to_string(bitfield_operation_type operation) const {
-		switch (operation) {
-			case bitfield_operation_type::get:
-				return "GET";
-			case bitfield_operation_type::set:
-				return "SET";
-			case bitfield_operation_type::incrby:
-				return "INCRBY";
-			default:
-				return "";
-		}
-	}
+std::string
+client::bitfield_operation_type_to_string(bitfield_operation_type operation) const {
+  switch (operation) {
+  case bitfield_operation_type::get:
+    return "GET";
+  case bitfield_operation_type::set:
+    return "SET";
+  case bitfield_operation_type::incrby:
+    return "INCRBY";
+  default:
+    return "";
+  }
+}
 
-	std::string
-	client::overflow_type_to_string(overflow_type type) const {
-		switch (type) {
-			case overflow_type::wrap:
-				return "WRAP";
-			case overflow_type::sat:
-				return "SAT";
-			case overflow_type::fail:
-				return "FAIL";
-			default:
-				return "";
-		}
-	}
+std::string
+client::overflow_type_to_string(overflow_type type) const {
+  switch (type) {
+  case overflow_type::wrap:
+    return "WRAP";
+  case overflow_type::sat:
+    return "SAT";
+  case overflow_type::fail:
+    return "FAIL";
+  default:
+    return "";
+  }
+}
 
-	client::bitfield_operation
-	client::bitfield_operation::get(const std::string &type, int offset, overflow_type overflow) {
-		return {bitfield_operation_type::get, type, offset, 0, overflow};
-	}
+client::bitfield_operation
+client::bitfield_operation::get(const std::string& type, int offset, overflow_type overflow) {
+  return {bitfield_operation_type::get, type, offset, 0, overflow};
+}
 
-	client::bitfield_operation
-	client::bitfield_operation::set(const std::string &type, int offset, int value, overflow_type overflow) {
-		return {bitfield_operation_type::set, type, offset, value, overflow};
-	}
+client::bitfield_operation
+client::bitfield_operation::set(const std::string& type, int offset, int value, overflow_type overflow) {
+  return {bitfield_operation_type::set, type, offset, value, overflow};
+}
 
-	client::bitfield_operation
-	client::bitfield_operation::incrby(const std::string &type, int offset, int increment, overflow_type overflow) {
-		return {bitfield_operation_type::incrby, type, offset, increment, overflow};
-	}
+client::bitfield_operation
+client::bitfield_operation::incrby(const std::string& type, int offset, int increment, overflow_type overflow) {
+  return {bitfield_operation_type::incrby, type, offset, increment, overflow};
+}
 
 /**
  * Redis commands
  * Callback-based
  */
 
-	client &
-	client::append(const std::string &key, const std::string &value, const reply_callback_t &reply_callback) {
-		send({"APPEND", key, value}, reply_callback);
-		return *this;
-	}
+client&
+client::append(const std::string& key, const std::string& value, const reply_callback_t& reply_callback) {
+  send({"APPEND", key, value}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::auth(const std::string &password, const reply_callback_t &reply_callback) {
-		std::lock_guard<std::mutex> lock(m_callbacks_mutex);
+client&
+client::auth(const std::string& password, const reply_callback_t& reply_callback) {
+  std::lock_guard<std::mutex> lock(m_callbacks_mutex);
 
-		unprotected_auth(password, reply_callback);
+  unprotected_auth(password, reply_callback);
 
-		return *this;
-	}
+  return *this;
+}
 
-	void
-	client::unprotected_auth(const std::string &password, const reply_callback_t &reply_callback) {
-/**
+void
+client::unprotected_auth(const std::string& password, const reply_callback_t& reply_callback) {
+  /**
  * save the password for reconnect attempts.
  */
-		m_password = password;
-/**
+  m_password = password;
+  /**
  * store command in pipeline
  */
-		unprotected_send({"AUTH", password}, reply_callback);
-	}
-
-	client &
-	client::bgrewriteaof(const reply_callback_t &reply_callback) {
-		send({"BGREWRITEAOF"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::bgsave(const reply_callback_t &reply_callback) {
-		send({"BGSAVE"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::bitcount(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"BITCOUNT", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::bitcount(const std::string &key, int start, int end, const reply_callback_t &reply_callback) {
-		send({"BITCOUNT", key, std::to_string(start), std::to_string(end)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::bitfield(const std::string &key, const std::vector<bitfield_operation> &operations,
-	                 const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"BITFIELD", key};
-
-		for (const auto &operation : operations) {
-			cmd.push_back(bitfield_operation_type_to_string(operation.operation_type));
-			cmd.push_back(operation.type);
-			cmd.push_back(std::to_string(operation.offset));
-
-			if (operation.operation_type == bitfield_operation_type::set ||
-			    operation.operation_type == bitfield_operation_type::incrby) {
-				cmd.push_back(std::to_string(operation.value));
-			}
-
-			if (operation.overflow != overflow_type::server_default) {
-				cmd.emplace_back("OVERFLOW");
-				cmd.push_back(overflow_type_to_string(operation.overflow));
-			}
-		}
-
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::bitop(const std::string &operation, const std::string &destkey, const std::vector<std::string> &keys,
-	              const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"BITOP", operation, destkey};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::bitpos(const std::string &key, int bit, const reply_callback_t &reply_callback) {
-		send({"BITPOS", key, std::to_string(bit)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::bitpos(const std::string &key, int bit, int start, const reply_callback_t &reply_callback) {
-		send({"BITPOS", key, std::to_string(bit), std::to_string(start)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::bitpos(const std::string &key, int bit, int start, int end, const reply_callback_t &reply_callback) {
-		send({"BITPOS", key, std::to_string(bit), std::to_string(start), std::to_string(end)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::blpop(const std::vector<std::string> &keys, int timeout, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"BLPOP"};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		cmd.push_back(std::to_string(timeout));
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::brpop(const std::vector<std::string> &keys, int timeout, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"BRPOP"};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		cmd.push_back(std::to_string(timeout));
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::brpoplpush(const std::string &src, const std::string &dst, int timeout,
-	                   const reply_callback_t &reply_callback) {
-		send({"BRPOPLPUSH", src, dst, std::to_string(timeout)}, reply_callback);
-		return *this;
-	}
-
-	client&
-	client::bzpopmin(const std::vector<std::string>& keys, int timeout, const reply_callback_t& reply_callback) {
-		std::vector<std::string> cmd = {"BZPOPMIN"};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		cmd.push_back(std::to_string(timeout));
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client&
-	client::bzpopmax(const std::vector<std::string>& keys, int timeout, const reply_callback_t& reply_callback) {
-		std::vector<std::string> cmd = {"BZPOPMAX"};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		cmd.push_back(std::to_string(timeout));
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client&
-	client::client_id(const reply_callback_t& reply_callback) {
-		send({"CLIENT", "ID"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::client_list(const reply_callback_t &reply_callback) {
-		send({"CLIENT", "LIST"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::client_getname(const reply_callback_t &reply_callback) {
-		send({"CLIENT", "GETNAME"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::client_pause(int timeout, const reply_callback_t &reply_callback) {
-		send({"CLIENT", "PAUSE", std::to_string(timeout)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::client_reply(const std::string &mode, const reply_callback_t &reply_callback) {
-		send({"CLIENT", "REPLY", mode}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::client_setname(const std::string &name, const reply_callback_t &reply_callback) {
-		send({"CLIENT", "SETNAME", name}, reply_callback);
-		return *this;
-	}
-
-	client&
-	client::client_unblock(int id, const reply_callback_t& reply_callback) {
-		send({"CLIENT", "UNBLOCK", std::to_string(id)}, reply_callback);
-		return *this;
-	}
-
-	client&
-	client::client_unblock(int id, bool witherror, const reply_callback_t& reply_callback) {
-		if (witherror)
-			send({"CLIENT", "UNBLOCK", std::to_string(id), "ERROR"}, reply_callback);
-		else
-			send({"CLIENT", "UNBLOCK", std::to_string(id)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_addslots(const std::vector<std::string> &p_slots, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"CLUSTER", "ADDSLOTS"};
-		cmd.insert(cmd.end(), p_slots.begin(), p_slots.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_count_failure_reports(const std::string &node_id, const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "COUNT-FAILURE-REPORTS", node_id}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_countkeysinslot(const std::string &slot, const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "COUNTKEYSINSLOT", slot}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_delslots(const std::vector<std::string> &p_slots, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"CLUSTER", "DELSLOTS"};
-		cmd.insert(cmd.end(), p_slots.begin(), p_slots.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_failover(const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "FAILOVER"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_failover(const std::string &mode, const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "FAILOVER", mode}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_forget(const std::string &node_id, const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "FORGET", node_id}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_getkeysinslot(const std::string &slot, int count, const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "GETKEYSINSLOT", slot, std::to_string(count)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_info(const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "INFO"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_keyslot(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "KEYSLOT", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_meet(const std::string &ip, int port, const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "MEET", ip, std::to_string(port)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_nodes(const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "NODES"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_replicate(const std::string &node_id, const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "REPLICATE", node_id}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_reset(const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "RESET"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_reset(const std::string &mode, const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "RESET", mode}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_saveconfig(const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "SAVECONFIG"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_set_config_epoch(const std::string &epoch, const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "SET-CONFIG-EPOCH", epoch}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_setslot(const std::string &slot, const std::string &mode, const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "SETSLOT", slot, mode}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_setslot(const std::string &slot, const std::string &mode, const std::string &node_id,
-	                        const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "SETSLOT", slot, mode, node_id}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_slaves(const std::string &node_id, const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "SLAVES", node_id}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::cluster_slots(const reply_callback_t &reply_callback) {
-		send({"CLUSTER", "SLOTS"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::command(const reply_callback_t &reply_callback) {
-		send({"COMMAND"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::command_count(const reply_callback_t &reply_callback) {
-		send({"COMMAND", "COUNT"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::command_getkeys(const reply_callback_t &reply_callback) {
-		send({"COMMAND", "GETKEYS"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::command_info(const std::vector<std::string> &command_name, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"COMMAND", "COUNT"};
-		cmd.insert(cmd.end(), command_name.begin(), command_name.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::config_get(const std::string &param, const reply_callback_t &reply_callback) {
-		send({"CONFIG", "GET", param}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::config_rewrite(const reply_callback_t &reply_callback) {
-		send({"CONFIG", "REWRITE"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::config_set(const std::string &param, const std::string &val, const reply_callback_t &reply_callback) {
-		send({"CONFIG", "SET", param, val}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::config_resetstat(const reply_callback_t &reply_callback) {
-		send({"CONFIG", "RESETSTAT"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::dbsize(const reply_callback_t &reply_callback) {
-		send({"DBSIZE"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::debug_object(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"DEBUG", "OBJECT", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::debug_segfault(const reply_callback_t &reply_callback) {
-		send({"DEBUG", "SEGFAULT"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::decr(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"DECR", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::decrby(const std::string &key, int val, const reply_callback_t &reply_callback) {
-		send({"DECRBY", key, std::to_string(val)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::del(const std::vector<std::string> &key, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"DEL"};
-		cmd.insert(cmd.end(), key.begin(), key.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::discard(const reply_callback_t &reply_callback) {
-		send({"DISCARD"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::dump(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"DUMP", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::echo(const std::string &msg, const reply_callback_t &reply_callback) {
-		send({"ECHO", msg}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::eval(const std::string &script, int numkeys, const std::vector<std::string> &keys,
-	             const std::vector<std::string> &args, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"EVAL", script, std::to_string(numkeys)};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		cmd.insert(cmd.end(), args.begin(), args.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::eval(const std::string &script, const std::vector<std::string> &keys,
-	             const std::vector<std::string> &args, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"EVAL", script, std::to_string(keys.size())};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		cmd.insert(cmd.end(), args.begin(), args.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::evalsha(const std::string &sha1, int numkeys, const std::vector<std::string> &keys,
-	                const std::vector<std::string> &args, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"EVALSHA", sha1, std::to_string(numkeys)};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		cmd.insert(cmd.end(), args.begin(), args.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::evalsha(const std::string &sha1, const std::vector<std::string> &keys,
-	                const std::vector<std::string> &args, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"EVALSHA", sha1, std::to_string(keys.size())};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		cmd.insert(cmd.end(), args.begin(), args.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::exec(const reply_callback_t &reply_callback) {
-		send({"EXEC"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::exists(const std::vector<std::string> &keys, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"EXISTS"};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::expire(const std::string &key, int seconds, const reply_callback_t &reply_callback) {
-		send({"EXPIRE", key, std::to_string(seconds)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::expireat(const std::string &key, int timestamp, const reply_callback_t &reply_callback) {
-		send({"EXPIREAT", key, std::to_string(timestamp)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::flushall(const reply_callback_t &reply_callback) {
-		send({"FLUSHALL"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::flushdb(const reply_callback_t &reply_callback) {
-		send({"FLUSHDB"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::geoadd(const std::string &key,
-	               const std::vector<std::tuple<std::string, std::string, std::string>> &long_lat_memb,
-	               const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"GEOADD", key};
-		for (const auto &obj : long_lat_memb) {
-			cmd.push_back(std::get<0>(obj));
-			cmd.push_back(std::get<1>(obj));
-			cmd.push_back(std::get<2>(obj));
-		}
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::geohash(const std::string &key, const std::vector<std::string> &members,
-	                const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"GEOHASH", key};
-		cmd.insert(cmd.end(), members.begin(), members.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::geopos(const std::string &key, const std::vector<std::string> &members,
-	               const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"GEOPOS", key};
-		cmd.insert(cmd.end(), members.begin(), members.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::geodist(const std::string &key, const std::string &member_1, const std::string &member_2,
-	                const reply_callback_t &reply_callback) {
-		send({"GEODIST", key, member_1, member_2}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::geodist(const std::string &key, const std::string &member_1, const std::string &member_2,
-	                const std::string &unit, const reply_callback_t &reply_callback) {
-		send({"GEODIST", key, member_1, member_2, unit}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
-	                  bool with_coord, bool with_dist, bool with_hash, bool asc_order,
-	                  const reply_callback_t &reply_callback) {
-		return georadius(key, longitude, latitude, radius, unit, with_coord, with_dist, with_hash, asc_order, 0, "", "",
-		                 reply_callback);
-	}
-
-	client &
-	client::georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
-	                  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
-	                  const reply_callback_t &reply_callback) {
-		return georadius(key, longitude, latitude, radius, unit, with_coord, with_dist, with_hash, asc_order, count, "", "",
-		                 reply_callback);
-	}
-
-	client &
-	client::georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
-	                  bool with_coord, bool with_dist, bool with_hash, bool asc_order, const std::string &store_key,
-	                  const reply_callback_t &reply_callback) {
-		return georadius(key, longitude, latitude, radius, unit, with_coord, with_dist, with_hash, asc_order, 0, store_key,
-		                 "", reply_callback);
-	}
-
-	client &
-	client::georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
-	                  bool with_coord, bool with_dist, bool with_hash, bool asc_order, const std::string &store_key,
-	                  const std::string &storedist_key, const reply_callback_t &reply_callback) {
-		return georadius(key, longitude, latitude, radius, unit, with_coord, with_dist, with_hash, asc_order, 0, store_key,
-		                 storedist_key, reply_callback);
-	}
-
-	client &
-	client::georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
-	                  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
-	                  const std::string &store_key, const reply_callback_t &reply_callback) {
-		return georadius(key, longitude, latitude, radius, unit, with_coord, with_dist, with_hash, asc_order, count,
-		                 store_key, "", reply_callback);
-	}
-
-	client &
-	client::georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
-	                  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
-	                  const std::string &store_key, const std::string &storedist_key,
-	                  const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"GEORADIUS", key, std::to_string(longitude), std::to_string(latitude),
-		                                std::to_string(radius), geo_unit_to_string(unit)};
-
-/**
+  unprotected_send({"AUTH", password}, reply_callback);
+}
+
+client&
+client::bgrewriteaof(const reply_callback_t& reply_callback) {
+  send({"BGREWRITEAOF"}, reply_callback);
+  return *this;
+}
+
+client&
+client::bgsave(const reply_callback_t& reply_callback) {
+  send({"BGSAVE"}, reply_callback);
+  return *this;
+}
+
+client&
+client::bitcount(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"BITCOUNT", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::bitcount(const std::string& key, int start, int end, const reply_callback_t& reply_callback) {
+  send({"BITCOUNT", key, std::to_string(start), std::to_string(end)}, reply_callback);
+  return *this;
+}
+
+client&
+client::bitfield(const std::string& key, const std::vector<bitfield_operation>& operations,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"BITFIELD", key};
+
+  for (const auto& operation : operations) {
+    cmd.push_back(bitfield_operation_type_to_string(operation.operation_type));
+    cmd.push_back(operation.type);
+    cmd.push_back(std::to_string(operation.offset));
+
+    if (operation.operation_type == bitfield_operation_type::set || operation.operation_type == bitfield_operation_type::incrby) {
+      cmd.push_back(std::to_string(operation.value));
+    }
+
+    if (operation.overflow != overflow_type::server_default) {
+      cmd.emplace_back("OVERFLOW");
+      cmd.push_back(overflow_type_to_string(operation.overflow));
+    }
+  }
+
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::bitop(const std::string& operation, const std::string& destkey, const std::vector<std::string>& keys,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"BITOP", operation, destkey};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::bitpos(const std::string& key, int bit, const reply_callback_t& reply_callback) {
+  send({"BITPOS", key, std::to_string(bit)}, reply_callback);
+  return *this;
+}
+
+client&
+client::bitpos(const std::string& key, int bit, int start, const reply_callback_t& reply_callback) {
+  send({"BITPOS", key, std::to_string(bit), std::to_string(start)}, reply_callback);
+  return *this;
+}
+
+client&
+client::bitpos(const std::string& key, int bit, int start, int end, const reply_callback_t& reply_callback) {
+  send({"BITPOS", key, std::to_string(bit), std::to_string(start), std::to_string(end)}, reply_callback);
+  return *this;
+}
+
+client&
+client::blpop(const std::vector<std::string>& keys, int timeout, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"BLPOP"};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  cmd.push_back(std::to_string(timeout));
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::brpop(const std::vector<std::string>& keys, int timeout, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"BRPOP"};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  cmd.push_back(std::to_string(timeout));
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::brpoplpush(const std::string& src, const std::string& dst, int timeout,
+  const reply_callback_t& reply_callback) {
+  send({"BRPOPLPUSH", src, dst, std::to_string(timeout)}, reply_callback);
+  return *this;
+}
+
+client&
+client::bzpopmin(const std::vector<std::string>& keys, int timeout, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"BZPOPMIN"};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  cmd.push_back(std::to_string(timeout));
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::bzpopmax(const std::vector<std::string>& keys, int timeout, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"BZPOPMAX"};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  cmd.push_back(std::to_string(timeout));
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::client_id(const reply_callback_t& reply_callback) {
+  send({"CLIENT", "ID"}, reply_callback);
+  return *this;
+}
+
+client&
+client::client_list(const reply_callback_t& reply_callback) {
+  send({"CLIENT", "LIST"}, reply_callback);
+  return *this;
+}
+
+client&
+client::client_getname(const reply_callback_t& reply_callback) {
+  send({"CLIENT", "GETNAME"}, reply_callback);
+  return *this;
+}
+
+client&
+client::client_pause(int timeout, const reply_callback_t& reply_callback) {
+  send({"CLIENT", "PAUSE", std::to_string(timeout)}, reply_callback);
+  return *this;
+}
+
+client&
+client::client_reply(const std::string& mode, const reply_callback_t& reply_callback) {
+  send({"CLIENT", "REPLY", mode}, reply_callback);
+  return *this;
+}
+
+client&
+client::client_setname(const std::string& name, const reply_callback_t& reply_callback) {
+  send({"CLIENT", "SETNAME", name}, reply_callback);
+  return *this;
+}
+
+client&
+client::client_unblock(int id, const reply_callback_t& reply_callback) {
+  send({"CLIENT", "UNBLOCK", std::to_string(id)}, reply_callback);
+  return *this;
+}
+
+client&
+client::client_unblock(int id, bool witherror, const reply_callback_t& reply_callback) {
+  if (witherror)
+    send({"CLIENT", "UNBLOCK", std::to_string(id), "ERROR"}, reply_callback);
+  else
+    send({"CLIENT", "UNBLOCK", std::to_string(id)}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_addslots(const std::vector<std::string>& p_slots, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"CLUSTER", "ADDSLOTS"};
+  cmd.insert(cmd.end(), p_slots.begin(), p_slots.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_count_failure_reports(const std::string& node_id, const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "COUNT-FAILURE-REPORTS", node_id}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_countkeysinslot(const std::string& slot, const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "COUNTKEYSINSLOT", slot}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_delslots(const std::vector<std::string>& p_slots, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"CLUSTER", "DELSLOTS"};
+  cmd.insert(cmd.end(), p_slots.begin(), p_slots.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_failover(const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "FAILOVER"}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_failover(const std::string& mode, const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "FAILOVER", mode}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_forget(const std::string& node_id, const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "FORGET", node_id}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_getkeysinslot(const std::string& slot, int count, const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "GETKEYSINSLOT", slot, std::to_string(count)}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_info(const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "INFO"}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_keyslot(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "KEYSLOT", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_meet(const std::string& ip, int port, const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "MEET", ip, std::to_string(port)}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_nodes(const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "NODES"}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_replicate(const std::string& node_id, const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "REPLICATE", node_id}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_reset(const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "RESET"}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_reset(const std::string& mode, const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "RESET", mode}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_saveconfig(const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "SAVECONFIG"}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_set_config_epoch(const std::string& epoch, const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "SET-CONFIG-EPOCH", epoch}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_setslot(const std::string& slot, const std::string& mode, const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "SETSLOT", slot, mode}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_setslot(const std::string& slot, const std::string& mode, const std::string& node_id,
+  const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "SETSLOT", slot, mode, node_id}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_slaves(const std::string& node_id, const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "SLAVES", node_id}, reply_callback);
+  return *this;
+}
+
+client&
+client::cluster_slots(const reply_callback_t& reply_callback) {
+  send({"CLUSTER", "SLOTS"}, reply_callback);
+  return *this;
+}
+
+client&
+client::command(const reply_callback_t& reply_callback) {
+  send({"COMMAND"}, reply_callback);
+  return *this;
+}
+
+client&
+client::command_count(const reply_callback_t& reply_callback) {
+  send({"COMMAND", "COUNT"}, reply_callback);
+  return *this;
+}
+
+client&
+client::command_getkeys(const reply_callback_t& reply_callback) {
+  send({"COMMAND", "GETKEYS"}, reply_callback);
+  return *this;
+}
+
+client&
+client::command_info(const std::vector<std::string>& command_name, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"COMMAND", "COUNT"};
+  cmd.insert(cmd.end(), command_name.begin(), command_name.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::config_get(const std::string& param, const reply_callback_t& reply_callback) {
+  send({"CONFIG", "GET", param}, reply_callback);
+  return *this;
+}
+
+client&
+client::config_rewrite(const reply_callback_t& reply_callback) {
+  send({"CONFIG", "REWRITE"}, reply_callback);
+  return *this;
+}
+
+client&
+client::config_set(const std::string& param, const std::string& val, const reply_callback_t& reply_callback) {
+  send({"CONFIG", "SET", param, val}, reply_callback);
+  return *this;
+}
+
+client&
+client::config_resetstat(const reply_callback_t& reply_callback) {
+  send({"CONFIG", "RESETSTAT"}, reply_callback);
+  return *this;
+}
+
+client&
+client::dbsize(const reply_callback_t& reply_callback) {
+  send({"DBSIZE"}, reply_callback);
+  return *this;
+}
+
+client&
+client::debug_object(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"DEBUG", "OBJECT", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::debug_segfault(const reply_callback_t& reply_callback) {
+  send({"DEBUG", "SEGFAULT"}, reply_callback);
+  return *this;
+}
+
+client&
+client::decr(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"DECR", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::decrby(const std::string& key, int val, const reply_callback_t& reply_callback) {
+  send({"DECRBY", key, std::to_string(val)}, reply_callback);
+  return *this;
+}
+
+client&
+client::del(const std::vector<std::string>& key, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"DEL"};
+  cmd.insert(cmd.end(), key.begin(), key.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::discard(const reply_callback_t& reply_callback) {
+  send({"DISCARD"}, reply_callback);
+  return *this;
+}
+
+client&
+client::dump(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"DUMP", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::echo(const std::string& msg, const reply_callback_t& reply_callback) {
+  send({"ECHO", msg}, reply_callback);
+  return *this;
+}
+
+client&
+client::eval(const std::string& script, int numkeys, const std::vector<std::string>& keys,
+  const std::vector<std::string>& args, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"EVAL", script, std::to_string(numkeys)};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  cmd.insert(cmd.end(), args.begin(), args.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::eval(const std::string& script, const std::vector<std::string>& keys,
+  const std::vector<std::string>& args, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"EVAL", script, std::to_string(keys.size())};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  cmd.insert(cmd.end(), args.begin(), args.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::evalsha(const std::string& sha1, int numkeys, const std::vector<std::string>& keys,
+  const std::vector<std::string>& args, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"EVALSHA", sha1, std::to_string(numkeys)};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  cmd.insert(cmd.end(), args.begin(), args.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::evalsha(const std::string& sha1, const std::vector<std::string>& keys,
+  const std::vector<std::string>& args, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"EVALSHA", sha1, std::to_string(keys.size())};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  cmd.insert(cmd.end(), args.begin(), args.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::exec(const reply_callback_t& reply_callback) {
+  send({"EXEC"}, reply_callback);
+  return *this;
+}
+
+client&
+client::exists(const std::vector<std::string>& keys, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"EXISTS"};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::expire(const std::string& key, int seconds, const reply_callback_t& reply_callback) {
+  send({"EXPIRE", key, std::to_string(seconds)}, reply_callback);
+  return *this;
+}
+
+client&
+client::expireat(const std::string& key, int timestamp, const reply_callback_t& reply_callback) {
+  send({"EXPIREAT", key, std::to_string(timestamp)}, reply_callback);
+  return *this;
+}
+
+client&
+client::flushall(const reply_callback_t& reply_callback) {
+  send({"FLUSHALL"}, reply_callback);
+  return *this;
+}
+
+client&
+client::flushdb(const reply_callback_t& reply_callback) {
+  send({"FLUSHDB"}, reply_callback);
+  return *this;
+}
+
+client&
+client::geoadd(const std::string& key,
+  const std::vector<std::tuple<std::string, std::string, std::string>>& long_lat_memb,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"GEOADD", key};
+  for (const auto& obj : long_lat_memb) {
+    cmd.push_back(std::get<0>(obj));
+    cmd.push_back(std::get<1>(obj));
+    cmd.push_back(std::get<2>(obj));
+  }
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::geohash(const std::string& key, const std::vector<std::string>& members,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"GEOHASH", key};
+  cmd.insert(cmd.end(), members.begin(), members.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::geopos(const std::string& key, const std::vector<std::string>& members,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"GEOPOS", key};
+  cmd.insert(cmd.end(), members.begin(), members.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::geodist(const std::string& key, const std::string& member_1, const std::string& member_2,
+  const reply_callback_t& reply_callback) {
+  send({"GEODIST", key, member_1, member_2}, reply_callback);
+  return *this;
+}
+
+client&
+client::geodist(const std::string& key, const std::string& member_1, const std::string& member_2,
+  const std::string& unit, const reply_callback_t& reply_callback) {
+  send({"GEODIST", key, member_1, member_2, unit}, reply_callback);
+  return *this;
+}
+
+client&
+client::georadius(const std::string& key, double longitude, double latitude, double radius, geo_unit unit,
+  bool with_coord, bool with_dist, bool with_hash, bool asc_order,
+  const reply_callback_t& reply_callback) {
+  return georadius(key, longitude, latitude, radius, unit, with_coord, with_dist, with_hash, asc_order, 0, "", "",
+    reply_callback);
+}
+
+client&
+client::georadius(const std::string& key, double longitude, double latitude, double radius, geo_unit unit,
+  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
+  const reply_callback_t& reply_callback) {
+  return georadius(key, longitude, latitude, radius, unit, with_coord, with_dist, with_hash, asc_order, count, "", "",
+    reply_callback);
+}
+
+client&
+client::georadius(const std::string& key, double longitude, double latitude, double radius, geo_unit unit,
+  bool with_coord, bool with_dist, bool with_hash, bool asc_order, const std::string& store_key,
+  const reply_callback_t& reply_callback) {
+  return georadius(key, longitude, latitude, radius, unit, with_coord, with_dist, with_hash, asc_order, 0, store_key,
+    "", reply_callback);
+}
+
+client&
+client::georadius(const std::string& key, double longitude, double latitude, double radius, geo_unit unit,
+  bool with_coord, bool with_dist, bool with_hash, bool asc_order, const std::string& store_key,
+  const std::string& storedist_key, const reply_callback_t& reply_callback) {
+  return georadius(key, longitude, latitude, radius, unit, with_coord, with_dist, with_hash, asc_order, 0, store_key,
+    storedist_key, reply_callback);
+}
+
+client&
+client::georadius(const std::string& key, double longitude, double latitude, double radius, geo_unit unit,
+  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
+  const std::string& store_key, const reply_callback_t& reply_callback) {
+  return georadius(key, longitude, latitude, radius, unit, with_coord, with_dist, with_hash, asc_order, count,
+    store_key, "", reply_callback);
+}
+
+client&
+client::georadius(const std::string& key, double longitude, double latitude, double radius, geo_unit unit,
+  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
+  const std::string& store_key, const std::string& storedist_key,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"GEORADIUS", key, std::to_string(longitude), std::to_string(latitude),
+    std::to_string(radius), geo_unit_to_string(unit)};
+
+  /**
  * with_coord (optional)
  */
-		if (with_coord) {
-			cmd.emplace_back("WITHCOORD");
-		}
+  if (with_coord) {
+    cmd.emplace_back("WITHCOORD");
+  }
 
-/**
+  /**
  * with_dist (optional)
  */
-		if (with_dist) {
-			cmd.emplace_back("WITHDIST");
-		}
+  if (with_dist) {
+    cmd.emplace_back("WITHDIST");
+  }
 
-/**
+  /**
  * with_hash (optional)
  */
-		if (with_hash) {
-			cmd.emplace_back("WITHHASH");
-		}
+  if (with_hash) {
+    cmd.emplace_back("WITHHASH");
+  }
 
-/**
+  /**
  * order (optional)
  */
-		cmd.emplace_back(asc_order ? "ASC" : "DESC");
+  cmd.emplace_back(asc_order ? "ASC" : "DESC");
 
-/**
+  /**
  * count (optional)
  */
-		if (count > 0) {
-			cmd.emplace_back("COUNT");
-			cmd.push_back(std::to_string(count));
-		}
+  if (count > 0) {
+    cmd.emplace_back("COUNT");
+    cmd.push_back(std::to_string(count));
+  }
 
-/**
+  /**
  * store_key (optional)
  */
-		if (!store_key.empty()) {
-			cmd.emplace_back("STOREDIST");
-			cmd.push_back(storedist_key);
-		}
+  if (!store_key.empty()) {
+    cmd.emplace_back("STOREDIST");
+    cmd.push_back(storedist_key);
+  }
 
-/**
+  /**
  * storedist_key (optional)
  */
-		if (!storedist_key.empty()) {
-			cmd.emplace_back("STOREDIST");
-			cmd.push_back(storedist_key);
-		}
+  if (!storedist_key.empty()) {
+    cmd.emplace_back("STOREDIST");
+    cmd.push_back(storedist_key);
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
-	                          bool with_coord, bool with_dist, bool with_hash, bool asc_order,
-	                          const reply_callback_t &reply_callback) {
-		return georadiusbymember(key, member, radius, unit, with_coord, with_dist, with_hash, asc_order, 0, "", "",
-		                         reply_callback);
-	}
+client&
+client::georadiusbymember(const std::string& key, const std::string& member, double radius, geo_unit unit,
+  bool with_coord, bool with_dist, bool with_hash, bool asc_order,
+  const reply_callback_t& reply_callback) {
+  return georadiusbymember(key, member, radius, unit, with_coord, with_dist, with_hash, asc_order, 0, "", "",
+    reply_callback);
+}
 
-	client &
-	client::georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
-	                          bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
-	                          const reply_callback_t &reply_callback) {
-		return georadiusbymember(key, member, radius, unit, with_coord, with_dist, with_hash, asc_order, count, "", "",
-		                         reply_callback);
-	}
+client&
+client::georadiusbymember(const std::string& key, const std::string& member, double radius, geo_unit unit,
+  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
+  const reply_callback_t& reply_callback) {
+  return georadiusbymember(key, member, radius, unit, with_coord, with_dist, with_hash, asc_order, count, "", "",
+    reply_callback);
+}
 
-	client &
-	client::georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
-	                          bool with_coord, bool with_dist, bool with_hash, bool asc_order,
-	                          const std::string &store_key, const reply_callback_t &reply_callback) {
-		return georadiusbymember(key, member, radius, unit, with_coord, with_dist, with_hash, asc_order, 0, store_key, "",
-		                         reply_callback);
-	}
+client&
+client::georadiusbymember(const std::string& key, const std::string& member, double radius, geo_unit unit,
+  bool with_coord, bool with_dist, bool with_hash, bool asc_order,
+  const std::string& store_key, const reply_callback_t& reply_callback) {
+  return georadiusbymember(key, member, radius, unit, with_coord, with_dist, with_hash, asc_order, 0, store_key, "",
+    reply_callback);
+}
 
-	client &
-	client::georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
-	                          bool with_coord, bool with_dist, bool with_hash, bool asc_order,
-	                          const std::string &store_key, const std::string &storedist_key,
-	                          const reply_callback_t &reply_callback) {
-		return georadiusbymember(key, member, radius, unit, with_coord, with_dist, with_hash, asc_order, 0, store_key,
-		                         storedist_key, reply_callback);
-	}
+client&
+client::georadiusbymember(const std::string& key, const std::string& member, double radius, geo_unit unit,
+  bool with_coord, bool with_dist, bool with_hash, bool asc_order,
+  const std::string& store_key, const std::string& storedist_key,
+  const reply_callback_t& reply_callback) {
+  return georadiusbymember(key, member, radius, unit, with_coord, with_dist, with_hash, asc_order, 0, store_key,
+    storedist_key, reply_callback);
+}
 
-	client &
-	client::georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
-	                          bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
-	                          const std::string &store_key, const reply_callback_t &reply_callback) {
-		return georadiusbymember(key, member, radius, unit, with_coord, with_dist, with_hash, asc_order, count, store_key,
-		                         "", reply_callback);
-	}
+client&
+client::georadiusbymember(const std::string& key, const std::string& member, double radius, geo_unit unit,
+  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
+  const std::string& store_key, const reply_callback_t& reply_callback) {
+  return georadiusbymember(key, member, radius, unit, with_coord, with_dist, with_hash, asc_order, count, store_key,
+    "", reply_callback);
+}
 
-	client &
-	client::georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
-	                          bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
-	                          const std::string &store_key, const std::string &storedist_key,
-	                          const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"GEORADIUSBYMEMBER", key, member, std::to_string(radius), geo_unit_to_string(unit)};
+client&
+client::georadiusbymember(const std::string& key, const std::string& member, double radius, geo_unit unit,
+  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
+  const std::string& store_key, const std::string& storedist_key,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"GEORADIUSBYMEMBER", key, member, std::to_string(radius), geo_unit_to_string(unit)};
 
-/**
+  /**
  * with_coord (optional)
  */
-		if (with_coord) {
-			cmd.emplace_back("WITHCOORD");
-		}
+  if (with_coord) {
+    cmd.emplace_back("WITHCOORD");
+  }
 
-/**
+  /**
  * with_dist (optional)
  */
-		if (with_dist) {
-			cmd.emplace_back("WITHDIST");
-		}
+  if (with_dist) {
+    cmd.emplace_back("WITHDIST");
+  }
 
-/**
+  /**
  * with_hash (optional)
  */
-		if (with_hash) {
-			cmd.emplace_back("WITHHASH");
-		}
+  if (with_hash) {
+    cmd.emplace_back("WITHHASH");
+  }
 
-/**
+  /**
  * order (optional)
  */
-		cmd.emplace_back(asc_order ? "ASC" : "DESC");
+  cmd.emplace_back(asc_order ? "ASC" : "DESC");
 
-/**
+  /**
  * count (optional)
  */
-		if (count > 0) {
-			cmd.emplace_back("COUNT");
-			cmd.push_back(std::to_string(count));
-		}
+  if (count > 0) {
+    cmd.emplace_back("COUNT");
+    cmd.push_back(std::to_string(count));
+  }
 
-/**
+  /**
  * store_key (optional)
  */
-		if (!store_key.empty()) {
-			cmd.emplace_back("STOREDIST");
-			cmd.push_back(storedist_key);
-		}
+  if (!store_key.empty()) {
+    cmd.emplace_back("STOREDIST");
+    cmd.push_back(storedist_key);
+  }
 
-/**
+  /**
  * storedist_key (optional)
  */
-		if (!storedist_key.empty()) {
-			cmd.emplace_back("STOREDIST");
-			cmd.push_back(storedist_key);
-		}
-
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::get(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"GET", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::getbit(const std::string &key, int offset, const reply_callback_t &reply_callback) {
-		send({"GETBIT", key, std::to_string(offset)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::getrange(const std::string &key, int start, int end, const reply_callback_t &reply_callback) {
-		send({"GETRANGE", key, std::to_string(start), std::to_string(end)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::getset(const std::string &key, const std::string &val, const reply_callback_t &reply_callback) {
-		send({"GETSET", key, val}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hdel(const std::string &key, const std::vector<std::string> &fields, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"HDEL", key};
-		cmd.insert(cmd.end(), fields.begin(), fields.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hexists(const std::string &key, const std::string &field, const reply_callback_t &reply_callback) {
-		send({"HEXISTS", key, field}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hget(const std::string &key, const std::string &field, const reply_callback_t &reply_callback) {
-		send({"HGET", key, field}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hgetall(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"HGETALL", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hincrby(const std::string &key, const std::string &field, int incr, const reply_callback_t &reply_callback) {
-		send({"HINCRBY", key, field, std::to_string(incr)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hincrbyfloat(const std::string &key, const std::string &field, float incr,
-	                     const reply_callback_t &reply_callback) {
-		send({"HINCRBYFLOAT", key, field, std::to_string(incr)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hkeys(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"HKEYS", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hlen(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"HLEN", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hmget(const std::string &key, const std::vector<std::string> &fields,
-	              const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"HMGET", key};
-		cmd.insert(cmd.end(), fields.begin(), fields.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hmset(const std::string &key, const std::vector<std::pair<std::string, std::string>> &field_val,
-	              const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"HMSET", key};
-		for (const auto &obj : field_val) {
-			cmd.push_back(obj.first);
-			cmd.push_back(obj.second);
-		}
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hscan(const std::string &key, std::size_t cursor, const reply_callback_t &reply_callback) {
-		return hscan(key, cursor, "", 0, reply_callback);
-	}
-
-	client &
-	client::hscan(const std::string &key, std::size_t cursor, const std::string &pattern,
-	              const reply_callback_t &reply_callback) {
-		return hscan(key, cursor, pattern, 0, reply_callback);
-	}
-
-	client &
-	client::hscan(const std::string &key, std::size_t cursor, std::size_t count, const reply_callback_t &reply_callback) {
-		return hscan(key, cursor, "", count, reply_callback);
-	}
-
-	client &
-	client::hscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count,
-	              const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"HSCAN", key, std::to_string(cursor)};
-
-		if (!pattern.empty()) {
-			cmd.emplace_back("MATCH");
-			cmd.push_back(pattern);
-		}
-
-		if (count > 0) {
-			cmd.emplace_back("COUNT");
-			cmd.push_back(std::to_string(count));
-		}
-
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hset(const std::string &key, const std::string &field, const std::string &value,
-	             const reply_callback_t &reply_callback) {
-		send({"HSET", key, field, value}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hsetnx(const std::string &key, const std::string &field, const std::string &value,
-	               const reply_callback_t &reply_callback) {
-		send({"HSETNX", key, field, value}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hstrlen(const std::string &key, const std::string &field, const reply_callback_t &reply_callback) {
-		send({"HSTRLEN", key, field}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::hvals(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"HVALS", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::incr(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"INCR", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::incrby(const std::string &key, int incr, const reply_callback_t &reply_callback) {
-		send({"INCRBY", key, std::to_string(incr)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::incrbyfloat(const std::string &key, float incr, const reply_callback_t &reply_callback) {
-		send({"INCRBYFLOAT", key, std::to_string(incr)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::info(const reply_callback_t &reply_callback) {
-		send({"INFO"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::info(const std::string &section, const reply_callback_t &reply_callback) {
-		send({"INFO", section}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::keys(const std::string &pattern, const reply_callback_t &reply_callback) {
-		send({"KEYS", pattern}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::lastsave(const reply_callback_t &reply_callback) {
-		send({"LASTSAVE"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::lindex(const std::string &key, int index, const reply_callback_t &reply_callback) {
-		send({"LINDEX", key, std::to_string(index)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::linsert(const std::string &key, const std::string &before_after, const std::string &pivot,
-	                const std::string &value, const reply_callback_t &reply_callback) {
-		send({"LINSERT", key, before_after, pivot, value}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::llen(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"LLEN", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::lpop(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"LPOP", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::lpush(const std::string &key, const std::vector<std::string> &values,
-	              const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"LPUSH", key};
-		cmd.insert(cmd.end(), values.begin(), values.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::lpushx(const std::string &key, const std::string &value, const reply_callback_t &reply_callback) {
-		send({"LPUSHX", key, value}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::lrange(const std::string &key, int start, int stop, const reply_callback_t &reply_callback) {
-		send({"LRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::lrem(const std::string &key, int count, const std::string &value, const reply_callback_t &reply_callback) {
-		send({"LREM", key, std::to_string(count), value}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::lset(const std::string &key, int index, const std::string &value, const reply_callback_t &reply_callback) {
-		send({"LSET", key, std::to_string(index), value}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::ltrim(const std::string &key, int start, int stop, const reply_callback_t &reply_callback) {
-		send({"LTRIM", key, std::to_string(start), std::to_string(stop)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::mget(const std::vector<std::string> &keys, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"MGET"};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::migrate(const std::string &host, int port, const std::string &key, const std::string &dest_db, int timeout,
-	                const reply_callback_t &reply_callback) {
-		send({"MIGRATE", host, std::to_string(port), key, dest_db, std::to_string(timeout)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::migrate(const std::string &host, int port, const std::string &key, const std::string &dest_db, int timeout,
-	                bool copy, bool replace, const std::vector<std::string> &keys,
-	                const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"MIGRATE", host, std::to_string(port), key, dest_db, std::to_string(timeout)};
-		if (copy) { cmd.emplace_back("COPY"); }
-		if (replace) { cmd.emplace_back("REPLACE"); }
-		if (!keys.empty()) {
-			cmd.emplace_back("KEYS");
-			cmd.insert(cmd.end(), keys.begin(), keys.end());
-		}
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::monitor(const reply_callback_t &reply_callback) {
-		send({"MONITOR"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::move(const std::string &key, const std::string &db, const reply_callback_t &reply_callback) {
-		send({"MOVE", key, db}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::mset(const std::vector<std::pair<std::string, std::string>> &key_vals,
-	             const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"MSET"};
-		for (const auto &obj : key_vals) {
-			cmd.push_back(obj.first);
-			cmd.push_back(obj.second);
-		}
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::msetnx(const std::vector<std::pair<std::string, std::string>> &key_vals,
-	               const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"MSETNX"};
-		for (const auto &obj : key_vals) {
-			cmd.push_back(obj.first);
-			cmd.push_back(obj.second);
-		}
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::multi(const reply_callback_t &reply_callback) {
-		send({"MULTI"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::object(const std::string &subcommand, const std::vector<std::string> &args,
-	               const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"OBJECT", subcommand};
-		cmd.insert(cmd.end(), args.begin(), args.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::persist(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"PERSIST", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::pexpire(const std::string &key, int ms, const reply_callback_t &reply_callback) {
-		send({"PEXPIRE", key, std::to_string(ms)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::pexpireat(const std::string &key, int ms_timestamp, const reply_callback_t &reply_callback) {
-		send({"PEXPIREAT", key, std::to_string(ms_timestamp)}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::pfadd(const std::string &key, const std::vector<std::string> &elements,
-	              const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"PFADD", key};
-		cmd.insert(cmd.end(), elements.begin(), elements.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::pfcount(const std::vector<std::string> &keys, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"PFCOUNT"};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::pfmerge(const std::string &destkey, const std::vector<std::string> &sourcekeys,
-	                const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"PFMERGE", destkey};
-		cmd.insert(cmd.end(), sourcekeys.begin(), sourcekeys.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::ping(const reply_callback_t &reply_callback) {
-		send({"PING"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::ping(const std::string &message, const reply_callback_t &reply_callback) {
-		send({"PING", message}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::psetex(const std::string &key, int64_t ms, const std::string &val,
-	               const reply_callback_t &reply_callback) {
-		send({"PSETEX", key, std::to_string(ms), val}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::publish(const std::string &channel, const std::string &message, const reply_callback_t &reply_callback) {
-		send({"PUBLISH", channel, message}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::pubsub(const std::string &subcommand, const std::vector<std::string> &args,
-	               const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"PUBSUB", subcommand};
-		cmd.insert(cmd.end(), args.begin(), args.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::pttl(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"PTTL", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::quit(const reply_callback_t &reply_callback) {
-		send({"QUIT"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::randomkey(const reply_callback_t &reply_callback) {
-		send({"RANDOMKEY"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::readonly(const reply_callback_t &reply_callback) {
-		send({"READONLY"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::readwrite(const reply_callback_t &reply_callback) {
-		send({"READWRITE"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::rename(const std::string &key, const std::string &newkey, const reply_callback_t &reply_callback) {
-		send({"RENAME", key, newkey}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::renamenx(const std::string &key, const std::string &newkey, const reply_callback_t &reply_callback) {
-		send({"RENAMENX", key, newkey}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::restore(const std::string &key, int ttl, const std::string &serialized_value,
-	                const reply_callback_t &reply_callback) {
-		send({"RESTORE", key, std::to_string(ttl), serialized_value}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::restore(const std::string &key, int ttl, const std::string &serialized_value, const std::string &replace,
-	                const reply_callback_t &reply_callback) {
-		send({"RESTORE", key, std::to_string(ttl), serialized_value, replace}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::role(const reply_callback_t &reply_callback) {
-		send({"ROLE"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::rpop(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"RPOP", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::rpoplpush(const std::string &source, const std::string &destination, const reply_callback_t &reply_callback) {
-		send({"RPOPLPUSH", source, destination}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::rpush(const std::string &key, const std::vector<std::string> &values,
-	              const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"RPUSH", key};
-		cmd.insert(cmd.end(), values.begin(), values.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::rpushx(const std::string &key, const std::string &value, const reply_callback_t &reply_callback) {
-		send({"RPUSHX", key, value}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::sadd(const std::string &key, const std::vector<std::string> &members,
-	             const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"SADD", key};
-		cmd.insert(cmd.end(), members.begin(), members.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::save(const reply_callback_t &reply_callback) {
-		send({"SAVE"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::scan(std::size_t cursor, const reply_callback_t &reply_callback) {
-		return scan(cursor, "", 0, reply_callback);
-	}
-
-	client &
-	client::scan(std::size_t cursor, const std::string &pattern, const reply_callback_t &reply_callback) {
-		return scan(cursor, pattern, 0, reply_callback);
-	}
-
-	client &
-	client::scan(std::size_t cursor, std::size_t count, const reply_callback_t &reply_callback) {
-		return scan(cursor, "", count, reply_callback);
-	}
-
-	client &
-	client::scan(std::size_t cursor, const std::string &pattern, std::size_t count,
-	             const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"SCAN", std::to_string(cursor)};
-
-		if (!pattern.empty()) {
-			cmd.emplace_back("MATCH");
-			cmd.push_back(pattern);
-		}
-
-		if (count > 0) {
-			cmd.emplace_back("COUNT");
-			cmd.push_back(std::to_string(count));
-		}
-
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::scard(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"SCARD", key}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::script_debug(const std::string &mode, const reply_callback_t &reply_callback) {
-		send({"SCRIPT", "DEBUG", mode}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::script_exists(const std::vector<std::string> &scripts, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"SCRIPT", "EXISTS"};
-		cmd.insert(cmd.end(), scripts.begin(), scripts.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::script_flush(const reply_callback_t &reply_callback) {
-		send({"SCRIPT", "FLUSH"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::script_kill(const reply_callback_t &reply_callback) {
-		send({"SCRIPT", "KILL"}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::script_load(const std::string &script, const reply_callback_t &reply_callback) {
-		send({"SCRIPT", "LOAD", script}, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::sdiff(const std::vector<std::string> &keys, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"SDIFF"};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::sdiffstore(const std::string &destination, const std::vector<std::string> &keys,
-	                   const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"SDIFFSTORE", destination};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
-
-	client &
-	client::select(int index, const reply_callback_t &reply_callback) {
-		std::lock_guard<std::mutex> lock(m_callbacks_mutex);
-
-		unprotected_select(index, reply_callback);
-
-		return *this;
-	}
-
-	void
-	client::unprotected_select(int index, const reply_callback_t &reply_callback) {
-/**
+  if (!storedist_key.empty()) {
+    cmd.emplace_back("STOREDIST");
+    cmd.push_back(storedist_key);
+  }
+
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::get(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"GET", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::getbit(const std::string& key, int offset, const reply_callback_t& reply_callback) {
+  send({"GETBIT", key, std::to_string(offset)}, reply_callback);
+  return *this;
+}
+
+client&
+client::getrange(const std::string& key, int start, int end, const reply_callback_t& reply_callback) {
+  send({"GETRANGE", key, std::to_string(start), std::to_string(end)}, reply_callback);
+  return *this;
+}
+
+client&
+client::getset(const std::string& key, const std::string& val, const reply_callback_t& reply_callback) {
+  send({"GETSET", key, val}, reply_callback);
+  return *this;
+}
+
+client&
+client::hdel(const std::string& key, const std::vector<std::string>& fields, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"HDEL", key};
+  cmd.insert(cmd.end(), fields.begin(), fields.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::hexists(const std::string& key, const std::string& field, const reply_callback_t& reply_callback) {
+  send({"HEXISTS", key, field}, reply_callback);
+  return *this;
+}
+
+client&
+client::hget(const std::string& key, const std::string& field, const reply_callback_t& reply_callback) {
+  send({"HGET", key, field}, reply_callback);
+  return *this;
+}
+
+client&
+client::hgetall(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"HGETALL", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::hincrby(const std::string& key, const std::string& field, int incr, const reply_callback_t& reply_callback) {
+  send({"HINCRBY", key, field, std::to_string(incr)}, reply_callback);
+  return *this;
+}
+
+client&
+client::hincrbyfloat(const std::string& key, const std::string& field, float incr,
+  const reply_callback_t& reply_callback) {
+  send({"HINCRBYFLOAT", key, field, std::to_string(incr)}, reply_callback);
+  return *this;
+}
+
+client&
+client::hkeys(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"HKEYS", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::hlen(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"HLEN", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::hmget(const std::string& key, const std::vector<std::string>& fields,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"HMGET", key};
+  cmd.insert(cmd.end(), fields.begin(), fields.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::hmset(const std::string& key, const std::vector<std::pair<std::string, std::string>>& field_val,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"HMSET", key};
+  for (const auto& obj : field_val) {
+    cmd.push_back(obj.first);
+    cmd.push_back(obj.second);
+  }
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::hscan(const std::string& key, std::size_t cursor, const reply_callback_t& reply_callback) {
+  return hscan(key, cursor, "", 0, reply_callback);
+}
+
+client&
+client::hscan(const std::string& key, std::size_t cursor, const std::string& pattern,
+  const reply_callback_t& reply_callback) {
+  return hscan(key, cursor, pattern, 0, reply_callback);
+}
+
+client&
+client::hscan(const std::string& key, std::size_t cursor, std::size_t count, const reply_callback_t& reply_callback) {
+  return hscan(key, cursor, "", count, reply_callback);
+}
+
+client&
+client::hscan(const std::string& key, std::size_t cursor, const std::string& pattern, std::size_t count,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"HSCAN", key, std::to_string(cursor)};
+
+  if (!pattern.empty()) {
+    cmd.emplace_back("MATCH");
+    cmd.push_back(pattern);
+  }
+
+  if (count > 0) {
+    cmd.emplace_back("COUNT");
+    cmd.push_back(std::to_string(count));
+  }
+
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::hset(const std::string& key, const std::string& field, const std::string& value,
+  const reply_callback_t& reply_callback) {
+  send({"HSET", key, field, value}, reply_callback);
+  return *this;
+}
+
+client&
+client::hsetnx(const std::string& key, const std::string& field, const std::string& value,
+  const reply_callback_t& reply_callback) {
+  send({"HSETNX", key, field, value}, reply_callback);
+  return *this;
+}
+
+client&
+client::hstrlen(const std::string& key, const std::string& field, const reply_callback_t& reply_callback) {
+  send({"HSTRLEN", key, field}, reply_callback);
+  return *this;
+}
+
+client&
+client::hvals(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"HVALS", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::incr(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"INCR", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::incrby(const std::string& key, int incr, const reply_callback_t& reply_callback) {
+  send({"INCRBY", key, std::to_string(incr)}, reply_callback);
+  return *this;
+}
+
+client&
+client::incrbyfloat(const std::string& key, float incr, const reply_callback_t& reply_callback) {
+  send({"INCRBYFLOAT", key, std::to_string(incr)}, reply_callback);
+  return *this;
+}
+
+client&
+client::info(const reply_callback_t& reply_callback) {
+  send({"INFO"}, reply_callback);
+  return *this;
+}
+
+client&
+client::info(const std::string& section, const reply_callback_t& reply_callback) {
+  send({"INFO", section}, reply_callback);
+  return *this;
+}
+
+client&
+client::keys(const std::string& pattern, const reply_callback_t& reply_callback) {
+  send({"KEYS", pattern}, reply_callback);
+  return *this;
+}
+
+client&
+client::lastsave(const reply_callback_t& reply_callback) {
+  send({"LASTSAVE"}, reply_callback);
+  return *this;
+}
+
+client&
+client::lindex(const std::string& key, int index, const reply_callback_t& reply_callback) {
+  send({"LINDEX", key, std::to_string(index)}, reply_callback);
+  return *this;
+}
+
+client&
+client::linsert(const std::string& key, const std::string& before_after, const std::string& pivot,
+  const std::string& value, const reply_callback_t& reply_callback) {
+  send({"LINSERT", key, before_after, pivot, value}, reply_callback);
+  return *this;
+}
+
+client&
+client::llen(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"LLEN", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::lpop(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"LPOP", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::lpush(const std::string& key, const std::vector<std::string>& values,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"LPUSH", key};
+  cmd.insert(cmd.end(), values.begin(), values.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::lpushx(const std::string& key, const std::string& value, const reply_callback_t& reply_callback) {
+  send({"LPUSHX", key, value}, reply_callback);
+  return *this;
+}
+
+client&
+client::lrange(const std::string& key, int start, int stop, const reply_callback_t& reply_callback) {
+  send({"LRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
+  return *this;
+}
+
+client&
+client::lrem(const std::string& key, int count, const std::string& value, const reply_callback_t& reply_callback) {
+  send({"LREM", key, std::to_string(count), value}, reply_callback);
+  return *this;
+}
+
+client&
+client::lset(const std::string& key, int index, const std::string& value, const reply_callback_t& reply_callback) {
+  send({"LSET", key, std::to_string(index), value}, reply_callback);
+  return *this;
+}
+
+client&
+client::ltrim(const std::string& key, int start, int stop, const reply_callback_t& reply_callback) {
+  send({"LTRIM", key, std::to_string(start), std::to_string(stop)}, reply_callback);
+  return *this;
+}
+
+client&
+client::mget(const std::vector<std::string>& keys, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"MGET"};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::migrate(const std::string& host, int port, const std::string& key, const std::string& dest_db, int timeout,
+  const reply_callback_t& reply_callback) {
+  send({"MIGRATE", host, std::to_string(port), key, dest_db, std::to_string(timeout)}, reply_callback);
+  return *this;
+}
+
+client&
+client::migrate(const std::string& host, int port, const std::string& key, const std::string& dest_db, int timeout,
+  bool copy, bool replace, const std::vector<std::string>& keys,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"MIGRATE", host, std::to_string(port), key, dest_db, std::to_string(timeout)};
+  if (copy) { cmd.emplace_back("COPY"); }
+  if (replace) { cmd.emplace_back("REPLACE"); }
+  if (!keys.empty()) {
+    cmd.emplace_back("KEYS");
+    cmd.insert(cmd.end(), keys.begin(), keys.end());
+  }
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::monitor(const reply_callback_t& reply_callback) {
+  send({"MONITOR"}, reply_callback);
+  return *this;
+}
+
+client&
+client::move(const std::string& key, const std::string& db, const reply_callback_t& reply_callback) {
+  send({"MOVE", key, db}, reply_callback);
+  return *this;
+}
+
+client&
+client::mset(const std::vector<std::pair<std::string, std::string>>& key_vals,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"MSET"};
+  for (const auto& obj : key_vals) {
+    cmd.push_back(obj.first);
+    cmd.push_back(obj.second);
+  }
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::msetnx(const std::vector<std::pair<std::string, std::string>>& key_vals,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"MSETNX"};
+  for (const auto& obj : key_vals) {
+    cmd.push_back(obj.first);
+    cmd.push_back(obj.second);
+  }
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::multi(const reply_callback_t& reply_callback) {
+  send({"MULTI"}, reply_callback);
+  return *this;
+}
+
+client&
+client::object(const std::string& subcommand, const std::vector<std::string>& args,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"OBJECT", subcommand};
+  cmd.insert(cmd.end(), args.begin(), args.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::persist(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"PERSIST", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::pexpire(const std::string& key, int ms, const reply_callback_t& reply_callback) {
+  send({"PEXPIRE", key, std::to_string(ms)}, reply_callback);
+  return *this;
+}
+
+client&
+client::pexpireat(const std::string& key, int ms_timestamp, const reply_callback_t& reply_callback) {
+  send({"PEXPIREAT", key, std::to_string(ms_timestamp)}, reply_callback);
+  return *this;
+}
+
+client&
+client::pfadd(const std::string& key, const std::vector<std::string>& elements,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"PFADD", key};
+  cmd.insert(cmd.end(), elements.begin(), elements.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::pfcount(const std::vector<std::string>& keys, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"PFCOUNT"};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::pfmerge(const std::string& destkey, const std::vector<std::string>& sourcekeys,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"PFMERGE", destkey};
+  cmd.insert(cmd.end(), sourcekeys.begin(), sourcekeys.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::ping(const reply_callback_t& reply_callback) {
+  send({"PING"}, reply_callback);
+  return *this;
+}
+
+client&
+client::ping(const std::string& message, const reply_callback_t& reply_callback) {
+  send({"PING", message}, reply_callback);
+  return *this;
+}
+
+client&
+client::psetex(const std::string& key, int64_t ms, const std::string& val,
+  const reply_callback_t& reply_callback) {
+  send({"PSETEX", key, std::to_string(ms), val}, reply_callback);
+  return *this;
+}
+
+client&
+client::publish(const std::string& channel, const std::string& message, const reply_callback_t& reply_callback) {
+  send({"PUBLISH", channel, message}, reply_callback);
+  return *this;
+}
+
+client&
+client::pubsub(const std::string& subcommand, const std::vector<std::string>& args,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"PUBSUB", subcommand};
+  cmd.insert(cmd.end(), args.begin(), args.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::pttl(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"PTTL", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::quit(const reply_callback_t& reply_callback) {
+  send({"QUIT"}, reply_callback);
+  return *this;
+}
+
+client&
+client::randomkey(const reply_callback_t& reply_callback) {
+  send({"RANDOMKEY"}, reply_callback);
+  return *this;
+}
+
+client&
+client::readonly(const reply_callback_t& reply_callback) {
+  send({"READONLY"}, reply_callback);
+  return *this;
+}
+
+client&
+client::readwrite(const reply_callback_t& reply_callback) {
+  send({"READWRITE"}, reply_callback);
+  return *this;
+}
+
+client&
+client::rename(const std::string& key, const std::string& newkey, const reply_callback_t& reply_callback) {
+  send({"RENAME", key, newkey}, reply_callback);
+  return *this;
+}
+
+client&
+client::renamenx(const std::string& key, const std::string& newkey, const reply_callback_t& reply_callback) {
+  send({"RENAMENX", key, newkey}, reply_callback);
+  return *this;
+}
+
+client&
+client::restore(const std::string& key, int ttl, const std::string& serialized_value,
+  const reply_callback_t& reply_callback) {
+  send({"RESTORE", key, std::to_string(ttl), serialized_value}, reply_callback);
+  return *this;
+}
+
+client&
+client::restore(const std::string& key, int ttl, const std::string& serialized_value, const std::string& replace,
+  const reply_callback_t& reply_callback) {
+  send({"RESTORE", key, std::to_string(ttl), serialized_value, replace}, reply_callback);
+  return *this;
+}
+
+client&
+client::role(const reply_callback_t& reply_callback) {
+  send({"ROLE"}, reply_callback);
+  return *this;
+}
+
+client&
+client::rpop(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"RPOP", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::rpoplpush(const std::string& source, const std::string& destination, const reply_callback_t& reply_callback) {
+  send({"RPOPLPUSH", source, destination}, reply_callback);
+  return *this;
+}
+
+client&
+client::rpush(const std::string& key, const std::vector<std::string>& values,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"RPUSH", key};
+  cmd.insert(cmd.end(), values.begin(), values.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::rpushx(const std::string& key, const std::string& value, const reply_callback_t& reply_callback) {
+  send({"RPUSHX", key, value}, reply_callback);
+  return *this;
+}
+
+client&
+client::sadd(const std::string& key, const std::vector<std::string>& members,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"SADD", key};
+  cmd.insert(cmd.end(), members.begin(), members.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::save(const reply_callback_t& reply_callback) {
+  send({"SAVE"}, reply_callback);
+  return *this;
+}
+
+client&
+client::scan(std::size_t cursor, const reply_callback_t& reply_callback) {
+  return scan(cursor, "", 0, reply_callback);
+}
+
+client&
+client::scan(std::size_t cursor, const std::string& pattern, const reply_callback_t& reply_callback) {
+  return scan(cursor, pattern, 0, reply_callback);
+}
+
+client&
+client::scan(std::size_t cursor, std::size_t count, const reply_callback_t& reply_callback) {
+  return scan(cursor, "", count, reply_callback);
+}
+
+client&
+client::scan(std::size_t cursor, const std::string& pattern, std::size_t count,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"SCAN", std::to_string(cursor)};
+
+  if (!pattern.empty()) {
+    cmd.emplace_back("MATCH");
+    cmd.push_back(pattern);
+  }
+
+  if (count > 0) {
+    cmd.emplace_back("COUNT");
+    cmd.push_back(std::to_string(count));
+  }
+
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::scard(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"SCARD", key}, reply_callback);
+  return *this;
+}
+
+client&
+client::script_debug(const std::string& mode, const reply_callback_t& reply_callback) {
+  send({"SCRIPT", "DEBUG", mode}, reply_callback);
+  return *this;
+}
+
+client&
+client::script_exists(const std::vector<std::string>& scripts, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"SCRIPT", "EXISTS"};
+  cmd.insert(cmd.end(), scripts.begin(), scripts.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::script_flush(const reply_callback_t& reply_callback) {
+  send({"SCRIPT", "FLUSH"}, reply_callback);
+  return *this;
+}
+
+client&
+client::script_kill(const reply_callback_t& reply_callback) {
+  send({"SCRIPT", "KILL"}, reply_callback);
+  return *this;
+}
+
+client&
+client::script_load(const std::string& script, const reply_callback_t& reply_callback) {
+  send({"SCRIPT", "LOAD", script}, reply_callback);
+  return *this;
+}
+
+client&
+client::sdiff(const std::vector<std::string>& keys, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"SDIFF"};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::sdiffstore(const std::string& destination, const std::vector<std::string>& keys,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"SDIFFSTORE", destination};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  send(cmd, reply_callback);
+  return *this;
+}
+
+client&
+client::select(int index, const reply_callback_t& reply_callback) {
+  std::lock_guard<std::mutex> lock(m_callbacks_mutex);
+
+  unprotected_select(index, reply_callback);
+
+  return *this;
+}
+
+void
+client::unprotected_select(int index, const reply_callback_t& reply_callback) {
+  /**
  * save the index of the database for reconnect attempts.
  */
-		m_database_index = index;
-/**
+  m_database_index = index;
+  /**
  * save command in the pipeline
  */
-		unprotected_send({"SELECT", std::to_string(index)}, reply_callback);
-	}
+  unprotected_send({"SELECT", std::to_string(index)}, reply_callback);
+}
 
-	client &
-	client::set(const std::string &key, const std::string &value, const reply_callback_t &reply_callback) {
-		send({"SET", key, value}, reply_callback);
-		return *this;
-	}
+client&
+client::set(const std::string& key, const std::string& value, const reply_callback_t& reply_callback) {
+  send({"SET", key, value}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::set_advanced(const std::string &key, const std::string &value, const reply_callback_t &reply_callback) {
-		send({"SET", key, value}, reply_callback);
-		return *this;
-	}
+client&
+client::set_advanced(const std::string& key, const std::string& value, const reply_callback_t& reply_callback) {
+  send({"SET", key, value}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::set_advanced(const std::string &key, const std::string &value, bool ex, int ex_sec, bool px, int px_milli,
-	                     bool nx, bool xx, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"SET", key, value};
-		if (ex) {
-			cmd.emplace_back("EX");
-			cmd.push_back(std::to_string(ex_sec));
-		}
-		if (px) {
-			cmd.emplace_back("PX");
-			cmd.push_back(std::to_string(px_milli));
-		}
-		if (nx) { cmd.emplace_back("NX"); }
-		if (xx) { cmd.emplace_back("XX"); }
-		send(cmd, reply_callback);
-		return *this;
-	}
+client&
+client::set_advanced(const std::string& key, const std::string& value, bool ex, int ex_sec, bool px, int px_milli,
+  bool nx, bool xx, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"SET", key, value};
+  if (ex) {
+    cmd.emplace_back("EX");
+    cmd.push_back(std::to_string(ex_sec));
+  }
+  if (px) {
+    cmd.emplace_back("PX");
+    cmd.push_back(std::to_string(px_milli));
+  }
+  if (nx) { cmd.emplace_back("NX"); }
+  if (xx) { cmd.emplace_back("XX"); }
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::setbit_(const std::string &key, int offset, const std::string &value,
-	                const reply_callback_t &reply_callback) {
-		send({"SETBIT", key, std::to_string(offset), value}, reply_callback);
-		return *this;
-	}
+client&
+client::setbit_(const std::string& key, int offset, const std::string& value,
+  const reply_callback_t& reply_callback) {
+  send({"SETBIT", key, std::to_string(offset), value}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::setex(const std::string &key, int64_t seconds, const std::string &value, const reply_callback_t &reply_callback) {
-		send({"SETEX", key, std::to_string(seconds), value}, reply_callback);
-		return *this;
-	}
+client&
+client::setex(const std::string& key, int64_t seconds, const std::string& value, const reply_callback_t& reply_callback) {
+  send({"SETEX", key, std::to_string(seconds), value}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::setnx(const std::string &key, const std::string &value, const reply_callback_t &reply_callback) {
-		send({"SETNX", key, value}, reply_callback);
-		return *this;
-	}
+client&
+client::setnx(const std::string& key, const std::string& value, const reply_callback_t& reply_callback) {
+  send({"SETNX", key, value}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::setrange(const std::string &key, int offset, const std::string &value,
-	                 const reply_callback_t &reply_callback) {
-		send({"SETRANGE", key, std::to_string(offset), value}, reply_callback);
-		return *this;
-	}
+client&
+client::setrange(const std::string& key, int offset, const std::string& value,
+  const reply_callback_t& reply_callback) {
+  send({"SETRANGE", key, std::to_string(offset), value}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::shutdown(const reply_callback_t &reply_callback) {
-		send({"SHUTDOWN"}, reply_callback);
-		return *this;
-	}
+client&
+client::shutdown(const reply_callback_t& reply_callback) {
+  send({"SHUTDOWN"}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::shutdown(const std::string &save, const reply_callback_t &reply_callback) {
-		send({"SHUTDOWN", save}, reply_callback);
-		return *this;
-	}
+client&
+client::shutdown(const std::string& save, const reply_callback_t& reply_callback) {
+  send({"SHUTDOWN", save}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::sinter(const std::vector<std::string> &keys, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"SINTER"};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
+client&
+client::sinter(const std::vector<std::string>& keys, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"SINTER"};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::sinterstore(const std::string &destination, const std::vector<std::string> &keys,
-	                    const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"SINTERSTORE", destination};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
+client&
+client::sinterstore(const std::string& destination, const std::vector<std::string>& keys,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"SINTERSTORE", destination};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::sismember(const std::string &key, const std::string &member, const reply_callback_t &reply_callback) {
-		send({"SISMEMBER", key, member}, reply_callback);
-		return *this;
-	}
+client&
+client::sismember(const std::string& key, const std::string& member, const reply_callback_t& reply_callback) {
+  send({"SISMEMBER", key, member}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::slaveof(const std::string &host, int port, const reply_callback_t &reply_callback) {
-		send({"SLAVEOF", host, std::to_string(port)}, reply_callback);
-		return *this;
-	}
+client&
+client::slaveof(const std::string& host, int port, const reply_callback_t& reply_callback) {
+  send({"SLAVEOF", host, std::to_string(port)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::slowlog(const std::string subcommand, const reply_callback_t &reply_callback) {
-		send({"SLOWLOG", subcommand}, reply_callback);
-		return *this;
-	}
+client&
+client::slowlog(const std::string subcommand, const reply_callback_t& reply_callback) {
+  send({"SLOWLOG", subcommand}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::slowlog(const std::string subcommand, const std::string &argument, const reply_callback_t &reply_callback) {
-		send({"SLOWLOG", subcommand, argument}, reply_callback);
-		return *this;
-	}
+client&
+client::slowlog(const std::string subcommand, const std::string& argument, const reply_callback_t& reply_callback) {
+  send({"SLOWLOG", subcommand, argument}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::smembers(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"SMEMBERS", key}, reply_callback);
-		return *this;
-	}
+client&
+client::smembers(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"SMEMBERS", key}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::smove(const std::string &source, const std::string &destination, const std::string &member,
-	              const reply_callback_t &reply_callback) {
-		send({"SMOVE", source, destination, member}, reply_callback);
-		return *this;
-	}
+client&
+client::smove(const std::string& source, const std::string& destination, const std::string& member,
+  const reply_callback_t& reply_callback) {
+  send({"SMOVE", source, destination, member}, reply_callback);
+  return *this;
+}
 
 
-	client &
-	client::sort(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"SORT", key}, reply_callback);
-		return *this;
-	}
+client&
+client::sort(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"SORT", key}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::sort(const std::string &key, const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
-	             const reply_callback_t &reply_callback) {
-		return sort(key, "", false, 0, 0, get_patterns, asc_order, alpha, "", reply_callback);
-	}
+client&
+client::sort(const std::string& key, const std::vector<std::string>& get_patterns, bool asc_order, bool alpha,
+  const reply_callback_t& reply_callback) {
+  return sort(key, "", false, 0, 0, get_patterns, asc_order, alpha, "", reply_callback);
+}
 
-	client &
-	client::sort(const std::string &key, std::size_t offset, std::size_t count,
-	             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
-	             const reply_callback_t &reply_callback) {
-		return sort(key, "", true, offset, count, get_patterns, asc_order, alpha, "", reply_callback);
-	}
+client&
+client::sort(const std::string& key, std::size_t offset, std::size_t count,
+  const std::vector<std::string>& get_patterns, bool asc_order, bool alpha,
+  const reply_callback_t& reply_callback) {
+  return sort(key, "", true, offset, count, get_patterns, asc_order, alpha, "", reply_callback);
+}
 
-	client &
-	client::sort(const std::string &key, const std::string &by_pattern, const std::vector<std::string> &get_patterns,
-	             bool asc_order, bool alpha, const reply_callback_t &reply_callback) {
-		return sort(key, by_pattern, false, 0, 0, get_patterns, asc_order, alpha, "", reply_callback);
-	}
+client&
+client::sort(const std::string& key, const std::string& by_pattern, const std::vector<std::string>& get_patterns,
+  bool asc_order, bool alpha, const reply_callback_t& reply_callback) {
+  return sort(key, by_pattern, false, 0, 0, get_patterns, asc_order, alpha, "", reply_callback);
+}
 
-	client &
-	client::sort(const std::string &key, const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
-	             const std::string &store_dest, const reply_callback_t &reply_callback) {
-		return sort(key, "", false, 0, 0, get_patterns, asc_order, alpha, store_dest, reply_callback);
-	}
+client&
+client::sort(const std::string& key, const std::vector<std::string>& get_patterns, bool asc_order, bool alpha,
+  const std::string& store_dest, const reply_callback_t& reply_callback) {
+  return sort(key, "", false, 0, 0, get_patterns, asc_order, alpha, store_dest, reply_callback);
+}
 
-	client &
-	client::sort(const std::string &key, std::size_t offset, std::size_t count,
-	             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha, const std::string &store_dest,
-	             const reply_callback_t &reply_callback) {
-		return sort(key, "", true, offset, count, get_patterns, asc_order, alpha, store_dest, reply_callback);
-	}
+client&
+client::sort(const std::string& key, std::size_t offset, std::size_t count,
+  const std::vector<std::string>& get_patterns, bool asc_order, bool alpha, const std::string& store_dest,
+  const reply_callback_t& reply_callback) {
+  return sort(key, "", true, offset, count, get_patterns, asc_order, alpha, store_dest, reply_callback);
+}
 
-	client &
-	client::sort(const std::string &key, const std::string &by_pattern, const std::vector<std::string> &get_patterns,
-	             bool asc_order, bool alpha, const std::string &store_dest, const reply_callback_t &reply_callback) {
-		return sort(key, by_pattern, false, 0, 0, get_patterns, asc_order, alpha, store_dest, reply_callback);
-	}
+client&
+client::sort(const std::string& key, const std::string& by_pattern, const std::vector<std::string>& get_patterns,
+  bool asc_order, bool alpha, const std::string& store_dest, const reply_callback_t& reply_callback) {
+  return sort(key, by_pattern, false, 0, 0, get_patterns, asc_order, alpha, store_dest, reply_callback);
+}
 
-	client &
-	client::sort(const std::string &key, const std::string &by_pattern, std::size_t offset, std::size_t count,
-	             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
-	             const reply_callback_t &reply_callback) {
-		return sort(key, by_pattern, true, offset, count, get_patterns, asc_order, alpha, "", reply_callback);
-	}
+client&
+client::sort(const std::string& key, const std::string& by_pattern, std::size_t offset, std::size_t count,
+  const std::vector<std::string>& get_patterns, bool asc_order, bool alpha,
+  const reply_callback_t& reply_callback) {
+  return sort(key, by_pattern, true, offset, count, get_patterns, asc_order, alpha, "", reply_callback);
+}
 
-	client &
-	client::sort(const std::string &key, const std::string &by_pattern, std::size_t offset, std::size_t count,
-	             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha, const std::string &store_dest,
-	             const reply_callback_t &reply_callback) {
-		return sort(key, by_pattern, true, offset, count, get_patterns, asc_order, alpha, store_dest, reply_callback);
-	}
+client&
+client::sort(const std::string& key, const std::string& by_pattern, std::size_t offset, std::size_t count,
+  const std::vector<std::string>& get_patterns, bool asc_order, bool alpha, const std::string& store_dest,
+  const reply_callback_t& reply_callback) {
+  return sort(key, by_pattern, true, offset, count, get_patterns, asc_order, alpha, store_dest, reply_callback);
+}
 
-	client &
-	client::sort(const std::string &key, const std::string &by_pattern, bool limit, std::size_t offset, std::size_t count,
-	             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha, const std::string &store_dest,
-	             const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"SORT", key};
+client&
+client::sort(const std::string& key, const std::string& by_pattern, bool limit, std::size_t offset, std::size_t count,
+  const std::vector<std::string>& get_patterns, bool asc_order, bool alpha, const std::string& store_dest,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"SORT", key};
 
-/**
+  /**
  * add by pattern (optional)
  */
-		if (!by_pattern.empty()) {
-			cmd.emplace_back("BY");
-			cmd.push_back(by_pattern);
-		}
+  if (!by_pattern.empty()) {
+    cmd.emplace_back("BY");
+    cmd.push_back(by_pattern);
+  }
 
-/**
+  /**
  * add limit (optional)
  */
-		if (limit) {
-			cmd.emplace_back("LIMIT");
-			cmd.push_back(std::to_string(offset));
-			cmd.push_back(std::to_string(count));
-		}
+  if (limit) {
+    cmd.emplace_back("LIMIT");
+    cmd.push_back(std::to_string(offset));
+    cmd.push_back(std::to_string(count));
+  }
 
-/**
+  /**
  * add get pattern (optional)
  */
-		for (const auto &get_pattern : get_patterns) {
-			if (get_pattern.empty()) {
-				continue;
-			}
+  for (const auto& get_pattern : get_patterns) {
+    if (get_pattern.empty()) {
+      continue;
+    }
 
-			cmd.emplace_back("GET");
-			cmd.push_back(get_pattern);
-		}
+    cmd.emplace_back("GET");
+    cmd.push_back(get_pattern);
+  }
 
-/**
+  /**
  * add order by (optional)
  */
-		cmd.emplace_back(asc_order ? "ASC" : "DESC");
+  cmd.emplace_back(asc_order ? "ASC" : "DESC");
 
-/**
+  /**
  * add alpha (optional)
  */
-		if (alpha) {
-			cmd.emplace_back("ALPHA");
-		}
+  if (alpha) {
+    cmd.emplace_back("ALPHA");
+  }
 
-/**
+  /**
  * add store dest (optional)
  */
-		if (!store_dest.empty()) {
-			cmd.emplace_back("STORE");
-			cmd.push_back(store_dest);
-		}
+  if (!store_dest.empty()) {
+    cmd.emplace_back("STORE");
+    cmd.push_back(store_dest);
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::spop(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"SPOP", key}, reply_callback);
-		return *this;
-	}
+client&
+client::spop(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"SPOP", key}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::spop(const std::string &key, int count, const reply_callback_t &reply_callback) {
-		send({"SPOP", key, std::to_string(count)}, reply_callback);
-		return *this;
-	}
+client&
+client::spop(const std::string& key, int count, const reply_callback_t& reply_callback) {
+  send({"SPOP", key, std::to_string(count)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::srandmember(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"SRANDMEMBER", key}, reply_callback);
-		return *this;
-	}
+client&
+client::srandmember(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"SRANDMEMBER", key}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::srandmember(const std::string &key, int count, const reply_callback_t &reply_callback) {
-		send({"SRANDMEMBER", key, std::to_string(count)}, reply_callback);
-		return *this;
-	}
+client&
+client::srandmember(const std::string& key, int count, const reply_callback_t& reply_callback) {
+  send({"SRANDMEMBER", key, std::to_string(count)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::srem(const std::string &key, const std::vector<std::string> &members,
-	             const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"SREM", key};
-		cmd.insert(cmd.end(), members.begin(), members.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
+client&
+client::srem(const std::string& key, const std::vector<std::string>& members,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"SREM", key};
+  cmd.insert(cmd.end(), members.begin(), members.end());
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::sscan(const std::string &key, std::size_t cursor, const reply_callback_t &reply_callback) {
-		return sscan(key, cursor, "", 0, reply_callback);
-	}
+client&
+client::sscan(const std::string& key, std::size_t cursor, const reply_callback_t& reply_callback) {
+  return sscan(key, cursor, "", 0, reply_callback);
+}
 
-	client &
-	client::sscan(const std::string &key, std::size_t cursor, const std::string &pattern,
-	              const reply_callback_t &reply_callback) {
-		return sscan(key, cursor, pattern, 0, reply_callback);
-	}
+client&
+client::sscan(const std::string& key, std::size_t cursor, const std::string& pattern,
+  const reply_callback_t& reply_callback) {
+  return sscan(key, cursor, pattern, 0, reply_callback);
+}
 
-	client &
-	client::sscan(const std::string &key, std::size_t cursor, std::size_t count, const reply_callback_t &reply_callback) {
-		return sscan(key, cursor, "", count, reply_callback);
-	}
+client&
+client::sscan(const std::string& key, std::size_t cursor, std::size_t count, const reply_callback_t& reply_callback) {
+  return sscan(key, cursor, "", count, reply_callback);
+}
 
-	client &
-	client::sscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count,
-	              const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"SSCAN", key, std::to_string(cursor)};
+client&
+client::sscan(const std::string& key, std::size_t cursor, const std::string& pattern, std::size_t count,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"SSCAN", key, std::to_string(cursor)};
 
-		if (!pattern.empty()) {
-			cmd.emplace_back("MATCH");
-			cmd.push_back(pattern);
-		}
+  if (!pattern.empty()) {
+    cmd.emplace_back("MATCH");
+    cmd.push_back(pattern);
+  }
 
-		if (count > 0) {
-			cmd.emplace_back("COUNT");
-			cmd.push_back(std::to_string(count));
-		}
+  if (count > 0) {
+    cmd.emplace_back("COUNT");
+    cmd.push_back(std::to_string(count));
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::strlen(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"STRLEN", key}, reply_callback);
-		return *this;
-	}
+client&
+client::strlen(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"STRLEN", key}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::sunion(const std::vector<std::string> &keys, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"SUNION"};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
+client&
+client::sunion(const std::vector<std::string>& keys, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"SUNION"};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::sunionstore(const std::string &destination, const std::vector<std::string> &keys,
-	                    const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"SUNIONSTORE", destination};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
+client&
+client::sunionstore(const std::string& destination, const std::vector<std::string>& keys,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"SUNIONSTORE", destination};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::sync(const reply_callback_t &reply_callback) {
-		send({"SYNC"}, reply_callback);
-		return *this;
-	}
+client&
+client::sync(const reply_callback_t& reply_callback) {
+  send({"SYNC"}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::time(const reply_callback_t &reply_callback) {
-		send({"TIME"}, reply_callback);
-		return *this;
-	}
+client&
+client::time(const reply_callback_t& reply_callback) {
+  send({"TIME"}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::ttl(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"TTL", key}, reply_callback);
-		return *this;
-	}
+client&
+client::ttl(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"TTL", key}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::type(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"TYPE", key}, reply_callback);
-		return *this;
-	}
+client&
+client::type(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"TYPE", key}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::unwatch(const reply_callback_t &reply_callback) {
-		send({"UNWATCH"}, reply_callback);
-		return *this;
-	}
+client&
+client::unwatch(const reply_callback_t& reply_callback) {
+  send({"UNWATCH"}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::wait(int numslaves, int timeout, const reply_callback_t &reply_callback) {
-		send({"WAIT", std::to_string(numslaves), std::to_string(timeout)}, reply_callback);
-		return *this;
-	}
+client&
+client::wait(int numslaves, int timeout, const reply_callback_t& reply_callback) {
+  send({"WAIT", std::to_string(numslaves), std::to_string(timeout)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::watch(const std::vector<std::string> &keys, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"WATCH"};
-		cmd.insert(cmd.end(), keys.begin(), keys.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
+client&
+client::watch(const std::vector<std::string>& keys, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"WATCH"};
+  cmd.insert(cmd.end(), keys.begin(), keys.end());
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::xack(const std::string &stream, const std::string &group, const std::vector<std::string> &message_ids,
-	             const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"XACK", stream, group};
+client&
+client::xack(const std::string& stream, const std::string& group, const std::vector<std::string>& message_ids,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"XACK", stream, group};
 
-/**
+  /**
  * ids
  */
-		for (auto &id : message_ids) {
-			cmd.push_back(id);
-		}
+  for (auto& id : message_ids) {
+    cmd.push_back(id);
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::xadd(const std::string &key, const std::string &id,
-	             const std::multimap<std::string, std::string> &field_members, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"XADD", key, id};
+client&
+client::xadd(const std::string& key, const std::string& id,
+  const std::multimap<std::string, std::string>& field_members, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"XADD", key, id};
 
-/**
+  /**
  * score members
  */
-		for (auto &sm : field_members) {
-			cmd.push_back(sm.first);
-			cmd.push_back(sm.second);
-		}
+  for (auto& sm : field_members) {
+    cmd.push_back(sm.first);
+    cmd.push_back(sm.second);
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::xclaim(const std::string &stream, const std::string &group, const std::string &consumer, int min_idle_time,
-	               const std::vector<std::string> &message_ids, const xclaim_options_t &options, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"XCLAIM", stream, group, consumer, std::to_string(min_idle_time)};
+client&
+client::xclaim(const std::string& stream, const std::string& group, const std::string& consumer, int min_idle_time,
+  const std::vector<std::string>& message_ids, const xclaim_options_t& options, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"XCLAIM", stream, group, consumer, std::to_string(min_idle_time)};
 
-/**
+  /**
  * ids
  */
-		for (auto &id : message_ids) {
-			cmd.push_back(id);
-		}
-		if (options.Idle > 0) {
-			cmd.emplace_back("IDLE");
-			cmd.push_back(std::to_string(options.Idle));
-		}
-		if (options.Time != nullptr) {
-			cmd.emplace_back("TIME");
-			cmd.push_back(std::to_string(static_cast<long int> (*options.Time)));
-		}
-		if (options.RetryCount > 0) {
-			cmd.emplace_back("RETRYCOUNT");
-			cmd.push_back(std::to_string(options.RetryCount));
-		}
-		if (options.Force) {
-			cmd.emplace_back("FORCE");
-		}
-		if (options.JustId) {
-			cmd.emplace_back("JUSTID");
-		}
+  for (auto& id : message_ids) {
+    cmd.push_back(id);
+  }
+  if (options.Idle > 0) {
+    cmd.emplace_back("IDLE");
+    cmd.push_back(std::to_string(options.Idle));
+  }
+  if (options.Time != nullptr) {
+    cmd.emplace_back("TIME");
+    cmd.push_back(std::to_string(static_cast<long int>(*options.Time)));
+  }
+  if (options.RetryCount > 0) {
+    cmd.emplace_back("RETRYCOUNT");
+    cmd.push_back(std::to_string(options.RetryCount));
+  }
+  if (options.Force) {
+    cmd.emplace_back("FORCE");
+  }
+  if (options.JustId) {
+    cmd.emplace_back("JUSTID");
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::xdel(const std::string &key, const std::vector<std::string> &id_members,
-	             const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"XDEL", key};
+client&
+client::xdel(const std::string& key, const std::vector<std::string>& id_members,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"XDEL", key};
 
-/**
+  /**
  * ids
  */
-		for (auto &id : id_members) {
-			cmd.push_back(id);
-		}
+  for (auto& id : id_members) {
+    cmd.push_back(id);
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	//<editor-fold desc="XGroup">
-	client &
-	client::xgroup_create(const std::string &key, const std::string &group_name, const reply_callback_t &reply_callback) {
-		send({"XGROUP", "CREATE", key, group_name, "$"}, reply_callback);
-		return *this;
-	}
+//<editor-fold desc="XGroup">
+client&
+client::xgroup_create(const std::string& key, const std::string& group_name, const reply_callback_t& reply_callback) {
+  send({"XGROUP", "CREATE", key, group_name, "$"}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::xgroup_create(const std::string &key, const std::string &group_name, const std::string &id,
-	                      const reply_callback_t &reply_callback) {
-		send({"XGROUP", "CREATE", key, group_name, id}, reply_callback);
-		return *this;
-	}
+client&
+client::xgroup_create(const std::string& key, const std::string& group_name, const std::string& id,
+  const reply_callback_t& reply_callback) {
+  send({"XGROUP", "CREATE", key, group_name, id}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::xgroup_set_id(const std::string &key, const std::string &group_name, const reply_callback_t &reply_callback) {
-		send({"XGROUP", "SETID", key, group_name, "$"}, reply_callback);
-		return *this;
-	}
+client&
+client::xgroup_set_id(const std::string& key, const std::string& group_name, const reply_callback_t& reply_callback) {
+  send({"XGROUP", "SETID", key, group_name, "$"}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::xgroup_set_id(const std::string &key, const std::string &group_name, const std::string &id,
-	                      const reply_callback_t &reply_callback) {
-		send({"XGROUP", "SETID", key, group_name, id}, reply_callback);
-		return *this;
-	}
+client&
+client::xgroup_set_id(const std::string& key, const std::string& group_name, const std::string& id,
+  const reply_callback_t& reply_callback) {
+  send({"XGROUP", "SETID", key, group_name, id}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::xgroup_destroy(const std::string &key, const std::string &group_name,
-	                       const reply_callback_t &reply_callback) {
-		send({"XGROUP", "DESTROY", key, group_name}, reply_callback);
-		return *this;
-	}
+client&
+client::xgroup_destroy(const std::string& key, const std::string& group_name,
+  const reply_callback_t& reply_callback) {
+  send({"XGROUP", "DESTROY", key, group_name}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::xgroup_del_consumer(const std::string &key, const std::string &group_name, const std::string &consumer_name,
-	                            const reply_callback_t &reply_callback) {
-		send({"XGROUP", "DELCONSUMER", key, group_name, consumer_name}, reply_callback);
-		return *this;
-	}
-	//</editor-fold>
+client&
+client::xgroup_del_consumer(const std::string& key, const std::string& group_name, const std::string& consumer_name,
+  const reply_callback_t& reply_callback) {
+  send({"XGROUP", "DELCONSUMER", key, group_name, consumer_name}, reply_callback);
+  return *this;
+}
+//</editor-fold>
 
-	client &client::xinfo_consumers(const std::string &key, const std::string &group_name,
-	                                const reply_callback_t &reply_callback) {
-		send({"XINFO", "CONSUMERS", key, group_name}, reply_callback);
-		return *this;
-	}
+client&
+client::xinfo_consumers(const std::string& key, const std::string& group_name,
+  const reply_callback_t& reply_callback) {
+  send({"XINFO", "CONSUMERS", key, group_name}, reply_callback);
+  return *this;
+}
 
-	client &client::xinfo_groups(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"XINFO", "GROUPS", key}, reply_callback);
-		return *this;
-	}
+client&
+client::xinfo_groups(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"XINFO", "GROUPS", key}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::xinfo_stream(const std::string &stream, const reply_callback_t &reply_callback) {
-		send({"XINFO", "STREAM", stream}, reply_callback);
-		return *this;
-	}
+client&
+client::xinfo_stream(const std::string& stream, const reply_callback_t& reply_callback) {
+  send({"XINFO", "STREAM", stream}, reply_callback);
+  return *this;
+}
 
-	/**
+/**
 	 * @brief Returns the number of entries inside a stream.
 	 * If the specified key does not exist the command returns zero, as if the stream was empty.
 	 * However note that unlike other Redis types, zero-length streams are possible, so you should call TYPE or EXISTS in order to check if a key exists or not.
@@ -2483,2480 +2486,2497 @@ namespace cpp_redis {
 	 * @param reply_callback
 	 * @return Integer reply: the number of entries of the stream at key.
 	 */
-	client &
-	client::xlen(const std::string &stream, const reply_callback_t &reply_callback) {
-		send({"XLEN", stream}, reply_callback);
-		return *this;
-	}
+client&
+client::xlen(const std::string& stream, const reply_callback_t& reply_callback) {
+  send({"XLEN", stream}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::xpending(const std::string &stream,
-	                 const std::string &group,
-	                 const xpending_options_t &options,
-	                 const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"XPENDING", stream, group};
-		if (!options.Range.Start.empty()) {
-			cmd.emplace_back(options.Range.Start);
-			cmd.emplace_back(options.Range.Stop);
-			cmd.emplace_back(std::to_string(options.Range.Count));
-		}
+client&
+client::xpending(const std::string& stream,
+  const std::string& group,
+  const xpending_options_t& options,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"XPENDING", stream, group};
+  if (!options.Range.Start.empty()) {
+    cmd.emplace_back(options.Range.Start);
+    cmd.emplace_back(options.Range.Stop);
+    cmd.emplace_back(std::to_string(options.Range.Count));
+  }
 
-		if (!options.Consumer.empty()) {
-			cmd.push_back(options.Consumer);
-		}
-		send(cmd, reply_callback);
-		return *this;
-	}
+  if (!options.Consumer.empty()) {
+    cmd.push_back(options.Consumer);
+  }
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::xrange(const std::string &stream, const range_options_t &options, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"XRANGE", stream, options.Start, options.Stop};
-		if (options.Count > 0) {
-			cmd.emplace_back("COUNT");
-			cmd.emplace_back(std::to_string(options.Count));
-		}
-		send(cmd, reply_callback);
-		return *this;
-	}
+client&
+client::xrange(const std::string& stream, const range_options_t& options, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"XRANGE", stream, options.Start, options.Stop};
+  if (options.Count > 0) {
+    cmd.emplace_back("COUNT");
+    cmd.emplace_back(std::to_string(options.Count));
+  }
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &client::xread(const xread_options_t &a, const client::reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"XREAD"};
-		if (a.Count > 0) {
-			cmd.emplace_back("COUNT");
-			cmd.push_back(std::to_string(a.Count));
-		}
+client&
+client::xread(const xread_options_t& a, const client::reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"XREAD"};
+  if (a.Count > 0) {
+    cmd.emplace_back("COUNT");
+    cmd.push_back(std::to_string(a.Count));
+  }
 
-		if (a.Block >= 0) {
-			cmd.emplace_back("BLOCK");
-			cmd.push_back(std::to_string(a.Block));
-		}
+  if (a.Block >= 0) {
+    cmd.emplace_back("BLOCK");
+    cmd.push_back(std::to_string(a.Block));
+  }
 
-		// Add streams
-		cmd.emplace_back("STREAMS");
-		cmd.insert(cmd.end(), a.Streams.first.begin(), a.Streams.first.end());
-		// Add ids
-		cmd.insert(cmd.end(), a.Streams.second.begin(), a.Streams.second.end());
+  // Add streams
+  cmd.emplace_back("STREAMS");
+  cmd.insert(cmd.end(), a.Streams.first.begin(), a.Streams.first.end());
+  // Add ids
+  cmd.insert(cmd.end(), a.Streams.second.begin(), a.Streams.second.end());
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::xreadgroup(const xreadgroup_options_t &a, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"XREADGROUP",
-		                                "GROUP", a.Group, a.Consumer};
-		if (a.Count > 0) {
-			cmd.emplace_back("COUNT");
-			cmd.push_back(std::to_string(a.Count));
-		}
+client&
+client::xreadgroup(const xreadgroup_options_t& a, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"XREADGROUP",
+    "GROUP", a.Group, a.Consumer};
+  if (a.Count > 0) {
+    cmd.emplace_back("COUNT");
+    cmd.push_back(std::to_string(a.Count));
+  }
 
-		if (a.Block >= 0) {
-			cmd.emplace_back("BLOCK");
-			cmd.push_back(std::to_string(a.Block));
-		}
+  if (a.Block >= 0) {
+    cmd.emplace_back("BLOCK");
+    cmd.push_back(std::to_string(a.Block));
+  }
 
-		if (a.NoAck) {
-			cmd.emplace_back("NOACK");
-		}
+  if (a.NoAck) {
+    cmd.emplace_back("NOACK");
+  }
 
-		// Add streams
-		cmd.emplace_back("STREAMS");
-		cmd.insert(cmd.end(), a.Streams.first.begin(), a.Streams.first.end());
-		// Add ids
-		cmd.insert(cmd.end(), a.Streams.second.begin(), a.Streams.second.end());
+  // Add streams
+  cmd.emplace_back("STREAMS");
+  cmd.insert(cmd.end(), a.Streams.first.begin(), a.Streams.first.end());
+  // Add ids
+  cmd.insert(cmd.end(), a.Streams.second.begin(), a.Streams.second.end());
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::xrevrange(const std::string &key, const range_options_t &range_args, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"XREVRANGE", key, range_args.Start, range_args.Stop};
-		if (range_args.Count > 0) {
-			cmd.emplace_back(std::to_string(range_args.Count));
-		}
-		send(cmd, reply_callback);
-		return *this;
-	}
+client&
+client::xrevrange(const std::string& key, const range_options_t& range_args, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"XREVRANGE", key, range_args.Start, range_args.Stop};
+  if (range_args.Count > 0) {
+    cmd.emplace_back(std::to_string(range_args.Count));
+  }
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &client::xtrim(const std::string &stream, int max_len, const client::reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"XTRIM", stream, "MAXLEN", std::to_string(max_len)};
-		send(cmd, reply_callback);
-		return *this;
-	}
+client&
+client::xtrim(const std::string& stream, int max_len, const client::reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"XTRIM", stream, "MAXLEN", std::to_string(max_len)};
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &client::xtrim_approx(const std::string &key, int max_len,
-	                             const cpp_redis::client::reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"XTRIM", key, "MAXLEN", "~", std::to_string(max_len)};
-		send(cmd, reply_callback);
-		return *this;
-	}
+client&
+client::xtrim_approx(const std::string& key, int max_len,
+  const cpp_redis::client::reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"XTRIM", key, "MAXLEN", "~", std::to_string(max_len)};
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zadd(const std::string &key, const std::vector<std::string> &options,
-	             const std::multimap<std::string, std::string> &score_members, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"ZADD", key};
+client&
+client::zadd(const std::string& key, const std::vector<std::string>& options,
+  const std::multimap<std::string, std::string>& score_members, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"ZADD", key};
 
-/**
+  /**
  * options
  */
-		cmd.insert(cmd.end(), options.begin(), options.end());
+  cmd.insert(cmd.end(), options.begin(), options.end());
 
-/**
+  /**
  * score members
  */
-		for (auto &sm : score_members) {
-			cmd.push_back(sm.first);
-			cmd.push_back(sm.second);
-		}
+  for (auto& sm : score_members) {
+    cmd.push_back(sm.first);
+    cmd.push_back(sm.second);
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zcard(const std::string &key, const reply_callback_t &reply_callback) {
-		send({"ZCARD", key}, reply_callback);
-		return *this;
-	}
+client&
+client::zcard(const std::string& key, const reply_callback_t& reply_callback) {
+  send({"ZCARD", key}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zcount(const std::string &key, int min, int max, const reply_callback_t &reply_callback) {
-		send({"ZCOUNT", key, std::to_string(min), std::to_string(max)}, reply_callback);
-		return *this;
-	}
+client&
+client::zcount(const std::string& key, int min, int max, const reply_callback_t& reply_callback) {
+  send({"ZCOUNT", key, std::to_string(min), std::to_string(max)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zcount(const std::string &key, double min, double max, const reply_callback_t &reply_callback) {
-		send({"ZCOUNT", key, std::to_string(min), std::to_string(max)}, reply_callback);
-		return *this;
-	}
+client&
+client::zcount(const std::string& key, double min, double max, const reply_callback_t& reply_callback) {
+  send({"ZCOUNT", key, std::to_string(min), std::to_string(max)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zcount(const std::string &key, const std::string &min, const std::string &max,
-	               const reply_callback_t &reply_callback) {
-		send({"ZCOUNT", key, min, max}, reply_callback);
-		return *this;
-	}
+client&
+client::zcount(const std::string& key, const std::string& min, const std::string& max,
+  const reply_callback_t& reply_callback) {
+  send({"ZCOUNT", key, min, max}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zincrby(const std::string &key, int incr, const std::string &member, const reply_callback_t &reply_callback) {
-		send({"ZINCRBY", key, std::to_string(incr), member}, reply_callback);
-		return *this;
-	}
+client&
+client::zincrby(const std::string& key, int incr, const std::string& member, const reply_callback_t& reply_callback) {
+  send({"ZINCRBY", key, std::to_string(incr), member}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zincrby(const std::string &key, double incr, const std::string &member,
-	                const reply_callback_t &reply_callback) {
-		send({"ZINCRBY", key, std::to_string(incr), member}, reply_callback);
-		return *this;
-	}
+client&
+client::zincrby(const std::string& key, double incr, const std::string& member,
+  const reply_callback_t& reply_callback) {
+  send({"ZINCRBY", key, std::to_string(incr), member}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zincrby(const std::string &key, const std::string &incr, const std::string &member,
-	                const reply_callback_t &reply_callback) {
-		send({"ZINCRBY", key, incr, member}, reply_callback);
-		return *this;
-	}
+client&
+client::zincrby(const std::string& key, const std::string& incr, const std::string& member,
+  const reply_callback_t& reply_callback) {
+  send({"ZINCRBY", key, incr, member}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zinterstore(const std::string &destination, std::size_t numkeys, const std::vector<std::string> &keys,
-	                    const std::vector<std::size_t> weights, aggregate_method method,
-	                    const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"ZINTERSTORE", destination, std::to_string(numkeys)};
+client&
+client::zinterstore(const std::string& destination, std::size_t numkeys, const std::vector<std::string>& keys,
+  const std::vector<std::size_t> weights, aggregate_method method,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"ZINTERSTORE", destination, std::to_string(numkeys)};
 
-/**
+  /**
  * keys
  */
-		for (const auto &key : keys) {
-			cmd.push_back(key);
-		}
+  for (const auto& key : keys) {
+    cmd.push_back(key);
+  }
 
-/**
+  /**
  * weights (optional)
  */
-		if (!weights.empty()) {
-			cmd.emplace_back("WEIGHTS");
+  if (!weights.empty()) {
+    cmd.emplace_back("WEIGHTS");
 
-			for (auto weight : weights) {
-				cmd.push_back(std::to_string(weight));
-			}
-		}
+    for (auto weight : weights) {
+      cmd.push_back(std::to_string(weight));
+    }
+  }
 
-/**
+  /**
  * aggregate method
  */
-		if (method != aggregate_method::server_default) {
-			cmd.emplace_back("AGGREGATE");
-			cmd.push_back(aggregate_method_to_string(method));
-		}
+  if (method != aggregate_method::server_default) {
+    cmd.emplace_back("AGGREGATE");
+    cmd.push_back(aggregate_method_to_string(method));
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zlexcount(const std::string &key, int min, int max, const reply_callback_t &reply_callback) {
-		send({"ZLEXCOUNT", key, std::to_string(min), std::to_string(max)}, reply_callback);
-		return *this;
-	}
+client&
+client::zlexcount(const std::string& key, int min, int max, const reply_callback_t& reply_callback) {
+  send({"ZLEXCOUNT", key, std::to_string(min), std::to_string(max)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zlexcount(const std::string &key, double min, double max, const reply_callback_t &reply_callback) {
-		send({"ZLEXCOUNT", key, std::to_string(min), std::to_string(max)}, reply_callback);
-		return *this;
-	}
+client&
+client::zlexcount(const std::string& key, double min, double max, const reply_callback_t& reply_callback) {
+  send({"ZLEXCOUNT", key, std::to_string(min), std::to_string(max)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zlexcount(const std::string &key, const std::string &min, const std::string &max,
-	                  const reply_callback_t &reply_callback) {
-		send({"ZLEXCOUNT", key, min, max}, reply_callback);
-		return *this;
-	}
+client&
+client::zlexcount(const std::string& key, const std::string& min, const std::string& max,
+  const reply_callback_t& reply_callback) {
+  send({"ZLEXCOUNT", key, min, max}, reply_callback);
+  return *this;
+}
 
-	client&
-	client::zpopmin(const std::string& key, int count, const reply_callback_t& reply_callback) {
-		send({"ZPOPMIN", key, std::to_string(count)}, reply_callback);
-		return *this;
-	}
+client&
+client::zpopmin(const std::string& key, int count, const reply_callback_t& reply_callback) {
+  send({"ZPOPMIN", key, std::to_string(count)}, reply_callback);
+  return *this;
+}
 
-	client&
-	client::zpopmax(const std::string& key, int count, const reply_callback_t& reply_callback) {
-		send({"ZPOPMAX", key, std::to_string(count)}, reply_callback);
-		return *this;
-	}
+client&
+client::zpopmax(const std::string& key, int count, const reply_callback_t& reply_callback) {
+  send({"ZPOPMAX", key, std::to_string(count)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrange(const std::string &key, int start, int stop, const reply_callback_t &reply_callback) {
-		send({"ZRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
-		return *this;
-	}
+client&
+client::zrange(const std::string& key, int start, int stop, const reply_callback_t& reply_callback) {
+  send({"ZRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrange(const std::string &key, int start, int stop, bool withscores, const reply_callback_t &reply_callback) {
-		if (withscores)
-			send({"ZRANGE", key, std::to_string(start), std::to_string(stop), "WITHSCORES"}, reply_callback);
-		else
-			send({"ZRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
-		return *this;
-	}
+client&
+client::zrange(const std::string& key, int start, int stop, bool withscores, const reply_callback_t& reply_callback) {
+  if (withscores)
+    send({"ZRANGE", key, std::to_string(start), std::to_string(stop), "WITHSCORES"}, reply_callback);
+  else
+    send({"ZRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrange(const std::string &key, double start, double stop, const reply_callback_t &reply_callback) {
-		send({"ZRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
-		return *this;
-	}
+client&
+client::zrange(const std::string& key, double start, double stop, const reply_callback_t& reply_callback) {
+  send({"ZRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrange(const std::string &key, double start, double stop, bool withscores,
-	               const reply_callback_t &reply_callback) {
-		if (withscores)
-			send({"ZRANGE", key, std::to_string(start), std::to_string(stop), "WITHSCORES"}, reply_callback);
-		else
-			send({"ZRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
-		return *this;
-	}
+client&
+client::zrange(const std::string& key, double start, double stop, bool withscores,
+  const reply_callback_t& reply_callback) {
+  if (withscores)
+    send({"ZRANGE", key, std::to_string(start), std::to_string(stop), "WITHSCORES"}, reply_callback);
+  else
+    send({"ZRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrange(const std::string &key, const std::string &start, const std::string &stop,
-	               const reply_callback_t &reply_callback) {
-		send({"ZRANGE", key, start, stop}, reply_callback);
-		return *this;
-	}
+client&
+client::zrange(const std::string& key, const std::string& start, const std::string& stop,
+  const reply_callback_t& reply_callback) {
+  send({"ZRANGE", key, start, stop}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrange(const std::string &key, const std::string &start, const std::string &stop, bool withscores,
-	               const reply_callback_t &reply_callback) {
-		if (withscores)
-			send({"ZRANGE", key, start, stop, "WITHSCORES"}, reply_callback);
-		else
-			send({"ZRANGE", key, start, stop}, reply_callback);
-		return *this;
-	}
+client&
+client::zrange(const std::string& key, const std::string& start, const std::string& stop, bool withscores,
+  const reply_callback_t& reply_callback) {
+  if (withscores)
+    send({"ZRANGE", key, start, stop, "WITHSCORES"}, reply_callback);
+  else
+    send({"ZRANGE", key, start, stop}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrangebylex(const std::string &key, int min, int max, const reply_callback_t &reply_callback) {
-		return zrangebylex(key, std::to_string(min), std::to_string(max), false, 0, 0, false, reply_callback);
-	}
+client&
+client::zrangebylex(const std::string& key, int min, int max, const reply_callback_t& reply_callback) {
+  return zrangebylex(key, std::to_string(min), std::to_string(max), false, 0, 0, false, reply_callback);
+}
 
-	client &
-	client::zrangebylex(const std::string &key, int min, int max, bool withscores,
-	                    const reply_callback_t &reply_callback) {
-		return zrangebylex(key, std::to_string(min), std::to_string(max), false, 0, 0, withscores, reply_callback);
-	}
+client&
+client::zrangebylex(const std::string& key, int min, int max, bool withscores,
+  const reply_callback_t& reply_callback) {
+  return zrangebylex(key, std::to_string(min), std::to_string(max), false, 0, 0, withscores, reply_callback);
+}
 
-	client &
-	client::zrangebylex(const std::string &key, double min, double max, const reply_callback_t &reply_callback) {
-		return zrangebylex(key, std::to_string(min), std::to_string(max), false, 0, 0, false, reply_callback);
-	}
+client&
+client::zrangebylex(const std::string& key, double min, double max, const reply_callback_t& reply_callback) {
+  return zrangebylex(key, std::to_string(min), std::to_string(max), false, 0, 0, false, reply_callback);
+}
 
-	client &
-	client::zrangebylex(const std::string &key, double min, double max, bool withscores,
-	                    const reply_callback_t &reply_callback) {
-		return zrangebylex(key, std::to_string(min), std::to_string(max), false, 0, 0, withscores, reply_callback);
-	}
+client&
+client::zrangebylex(const std::string& key, double min, double max, bool withscores,
+  const reply_callback_t& reply_callback) {
+  return zrangebylex(key, std::to_string(min), std::to_string(max), false, 0, 0, withscores, reply_callback);
+}
 
-	client &
-	client::zrangebylex(const std::string &key, const std::string &min, const std::string &max,
-	                    const reply_callback_t &reply_callback) {
-		return zrangebylex(key, min, max, false, 0, 0, false, reply_callback);
-	}
+client&
+client::zrangebylex(const std::string& key, const std::string& min, const std::string& max,
+  const reply_callback_t& reply_callback) {
+  return zrangebylex(key, min, max, false, 0, 0, false, reply_callback);
+}
 
-	client &
-	client::zrangebylex(const std::string &key, const std::string &min, const std::string &max, bool withscores,
-	                    const reply_callback_t &reply_callback) {
-		return zrangebylex(key, min, max, false, 0, 0, withscores, reply_callback);
-	}
+client&
+client::zrangebylex(const std::string& key, const std::string& min, const std::string& max, bool withscores,
+  const reply_callback_t& reply_callback) {
+  return zrangebylex(key, min, max, false, 0, 0, withscores, reply_callback);
+}
 
-	client &
-	client::zrangebylex(const std::string &key, int min, int max, std::size_t offset, std::size_t count,
-	                    const reply_callback_t &reply_callback) {
-		return zrangebylex(key, std::to_string(min), std::to_string(max), true, offset, count, false, reply_callback);
-	}
+client&
+client::zrangebylex(const std::string& key, int min, int max, std::size_t offset, std::size_t count,
+  const reply_callback_t& reply_callback) {
+  return zrangebylex(key, std::to_string(min), std::to_string(max), true, offset, count, false, reply_callback);
+}
 
-	client &
-	client::zrangebylex(const std::string &key, int min, int max, std::size_t offset, std::size_t count, bool withscores,
-	                    const reply_callback_t &reply_callback) {
-		return zrangebylex(key, std::to_string(min), std::to_string(max), true, offset, count, withscores, reply_callback);
-	}
+client&
+client::zrangebylex(const std::string& key, int min, int max, std::size_t offset, std::size_t count, bool withscores,
+  const reply_callback_t& reply_callback) {
+  return zrangebylex(key, std::to_string(min), std::to_string(max), true, offset, count, withscores, reply_callback);
+}
 
-	client &
-	client::zrangebylex(const std::string &key, double min, double max, std::size_t offset, std::size_t count,
-	                    const reply_callback_t &reply_callback) {
-		return zrangebylex(key, std::to_string(min), std::to_string(max), true, offset, count, false, reply_callback);
-	}
+client&
+client::zrangebylex(const std::string& key, double min, double max, std::size_t offset, std::size_t count,
+  const reply_callback_t& reply_callback) {
+  return zrangebylex(key, std::to_string(min), std::to_string(max), true, offset, count, false, reply_callback);
+}
 
-	client &
-	client::zrangebylex(const std::string &key, double min, double max, std::size_t offset, std::size_t count,
-	                    bool withscores, const reply_callback_t &reply_callback) {
-		return zrangebylex(key, std::to_string(min), std::to_string(max), true, offset, count, withscores, reply_callback);
-	}
+client&
+client::zrangebylex(const std::string& key, double min, double max, std::size_t offset, std::size_t count,
+  bool withscores, const reply_callback_t& reply_callback) {
+  return zrangebylex(key, std::to_string(min), std::to_string(max), true, offset, count, withscores, reply_callback);
+}
 
-	client &
-	client::zrangebylex(const std::string &key, const std::string &min, const std::string &max, std::size_t offset,
-	                    std::size_t count, const reply_callback_t &reply_callback) {
-		return zrangebylex(key, min, max, true, offset, count, false, reply_callback);
-	}
+client&
+client::zrangebylex(const std::string& key, const std::string& min, const std::string& max, std::size_t offset,
+  std::size_t count, const reply_callback_t& reply_callback) {
+  return zrangebylex(key, min, max, true, offset, count, false, reply_callback);
+}
 
-	client &
-	client::zrangebylex(const std::string &key, const std::string &min, const std::string &max, std::size_t offset,
-	                    std::size_t count, bool withscores, const reply_callback_t &reply_callback) {
-		return zrangebylex(key, min, max, true, offset, count, withscores, reply_callback);
-	}
+client&
+client::zrangebylex(const std::string& key, const std::string& min, const std::string& max, std::size_t offset,
+  std::size_t count, bool withscores, const reply_callback_t& reply_callback) {
+  return zrangebylex(key, min, max, true, offset, count, withscores, reply_callback);
+}
 
-	client &
-	client::zrangebylex(const std::string &key, const std::string &min, const std::string &max, bool limit,
-	                    std::size_t offset, std::size_t count, bool withscores, const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"ZRANGEBYLEX", key, min, max};
+client&
+client::zrangebylex(const std::string& key, const std::string& min, const std::string& max, bool limit,
+  std::size_t offset, std::size_t count, bool withscores, const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"ZRANGEBYLEX", key, min, max};
 
-/**
+  /**
  * withscores (optional)
  */
-		if (withscores) {
-			cmd.emplace_back("WITHSCORES");
-		}
+  if (withscores) {
+    cmd.emplace_back("WITHSCORES");
+  }
 
-/**
+  /**
  * limit (optional)
  */
-		if (limit) {
-			cmd.emplace_back("LIMIT");
-			cmd.push_back(std::to_string(offset));
-			cmd.push_back(std::to_string(count));
-		}
+  if (limit) {
+    cmd.emplace_back("LIMIT");
+    cmd.push_back(std::to_string(offset));
+    cmd.push_back(std::to_string(count));
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrangebyscore(const std::string &key, int min, int max, const reply_callback_t &reply_callback) {
-		return zrangebyscore(key, std::to_string(min), std::to_string(max), false, 0, 0, false, reply_callback);
-	}
+client&
+client::zrangebyscore(const std::string& key, int min, int max, const reply_callback_t& reply_callback) {
+  return zrangebyscore(key, std::to_string(min), std::to_string(max), false, 0, 0, false, reply_callback);
+}
 
-	client &
-	client::zrangebyscore(const std::string &key, int min, int max, bool withscores,
-	                      const reply_callback_t &reply_callback) {
-		return zrangebyscore(key, std::to_string(min), std::to_string(max), false, 0, 0, withscores, reply_callback);
-	}
+client&
+client::zrangebyscore(const std::string& key, int min, int max, bool withscores,
+  const reply_callback_t& reply_callback) {
+  return zrangebyscore(key, std::to_string(min), std::to_string(max), false, 0, 0, withscores, reply_callback);
+}
 
-	client &
-	client::zrangebyscore(const std::string &key, double min, double max, const reply_callback_t &reply_callback) {
-		return zrangebyscore(key, std::to_string(min), std::to_string(max), false, 0, 0, false, reply_callback);
-	}
+client&
+client::zrangebyscore(const std::string& key, double min, double max, const reply_callback_t& reply_callback) {
+  return zrangebyscore(key, std::to_string(min), std::to_string(max), false, 0, 0, false, reply_callback);
+}
 
-	client &
-	client::zrangebyscore(const std::string &key, double min, double max, bool withscores,
-	                      const reply_callback_t &reply_callback) {
-		return zrangebyscore(key, std::to_string(min), std::to_string(max), false, 0, 0, withscores, reply_callback);
-	}
+client&
+client::zrangebyscore(const std::string& key, double min, double max, bool withscores,
+  const reply_callback_t& reply_callback) {
+  return zrangebyscore(key, std::to_string(min), std::to_string(max), false, 0, 0, withscores, reply_callback);
+}
 
-	client &
-	client::zrangebyscore(const std::string &key, const std::string &min, const std::string &max,
-	                      const reply_callback_t &reply_callback) {
-		return zrangebyscore(key, min, max, false, 0, 0, false, reply_callback);
-	}
+client&
+client::zrangebyscore(const std::string& key, const std::string& min, const std::string& max,
+  const reply_callback_t& reply_callback) {
+  return zrangebyscore(key, min, max, false, 0, 0, false, reply_callback);
+}
 
-	client &
-	client::zrangebyscore(const std::string &key, const std::string &min, const std::string &max, bool withscores,
-	                      const reply_callback_t &reply_callback) {
-		return zrangebyscore(key, min, max, false, 0, 0, withscores, reply_callback);
-	}
+client&
+client::zrangebyscore(const std::string& key, const std::string& min, const std::string& max, bool withscores,
+  const reply_callback_t& reply_callback) {
+  return zrangebyscore(key, min, max, false, 0, 0, withscores, reply_callback);
+}
 
-	client &
-	client::zrangebyscore(const std::string &key, int min, int max, std::size_t offset, std::size_t count,
-	                      const reply_callback_t &reply_callback) {
-		return zrangebyscore(key, std::to_string(min), std::to_string(max), true, offset, count, false, reply_callback);
-	}
+client&
+client::zrangebyscore(const std::string& key, int min, int max, std::size_t offset, std::size_t count,
+  const reply_callback_t& reply_callback) {
+  return zrangebyscore(key, std::to_string(min), std::to_string(max), true, offset, count, false, reply_callback);
+}
 
-	client &
-	client::zrangebyscore(const std::string &key, int min, int max, std::size_t offset, std::size_t count,
-	                      bool withscores, const reply_callback_t &reply_callback) {
-		return zrangebyscore(key, std::to_string(min), std::to_string(max), true, offset, count, withscores,
-		                     reply_callback);
-	}
+client&
+client::zrangebyscore(const std::string& key, int min, int max, std::size_t offset, std::size_t count,
+  bool withscores, const reply_callback_t& reply_callback) {
+  return zrangebyscore(key, std::to_string(min), std::to_string(max), true, offset, count, withscores,
+    reply_callback);
+}
 
-	client &
-	client::zrangebyscore(const std::string &key, double min, double max, std::size_t offset, std::size_t count,
-	                      const reply_callback_t &reply_callback) {
-		return zrangebyscore(key, std::to_string(min), std::to_string(max), true, offset, count, false, reply_callback);
-	}
+client&
+client::zrangebyscore(const std::string& key, double min, double max, std::size_t offset, std::size_t count,
+  const reply_callback_t& reply_callback) {
+  return zrangebyscore(key, std::to_string(min), std::to_string(max), true, offset, count, false, reply_callback);
+}
 
-	client &
-	client::zrangebyscore(const std::string &key, double min, double max, std::size_t offset, std::size_t count,
-	                      bool withscores, const reply_callback_t &reply_callback) {
-		return zrangebyscore(key, std::to_string(min), std::to_string(max), true, offset, count, withscores,
-		                     reply_callback);
-	}
+client&
+client::zrangebyscore(const std::string& key, double min, double max, std::size_t offset, std::size_t count,
+  bool withscores, const reply_callback_t& reply_callback) {
+  return zrangebyscore(key, std::to_string(min), std::to_string(max), true, offset, count, withscores,
+    reply_callback);
+}
 
-	client &
-	client::zrangebyscore(const std::string &key, const std::string &min, const std::string &max, std::size_t offset,
-	                      std::size_t count, const reply_callback_t &reply_callback) {
-		return zrangebyscore(key, min, max, true, offset, count, false, reply_callback);
-	}
+client&
+client::zrangebyscore(const std::string& key, const std::string& min, const std::string& max, std::size_t offset,
+  std::size_t count, const reply_callback_t& reply_callback) {
+  return zrangebyscore(key, min, max, true, offset, count, false, reply_callback);
+}
 
-	client &
-	client::zrangebyscore(const std::string &key, const std::string &min, const std::string &max, std::size_t offset,
-	                      std::size_t count, bool withscores, const reply_callback_t &reply_callback) {
-		return zrangebyscore(key, min, max, true, offset, count, withscores, reply_callback);
-	}
+client&
+client::zrangebyscore(const std::string& key, const std::string& min, const std::string& max, std::size_t offset,
+  std::size_t count, bool withscores, const reply_callback_t& reply_callback) {
+  return zrangebyscore(key, min, max, true, offset, count, withscores, reply_callback);
+}
 
-	client &
-	client::zrangebyscore(const std::string &key, const std::string &min, const std::string &max, bool limit,
-	                      std::size_t offset, std::size_t count, bool withscores,
-	                      const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"ZRANGEBYSCORE", key, min, max};
+client&
+client::zrangebyscore(const std::string& key, const std::string& min, const std::string& max, bool limit,
+  std::size_t offset, std::size_t count, bool withscores,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"ZRANGEBYSCORE", key, min, max};
 
-/**
+  /**
  * withscores (optional)
  */
-		if (withscores) {
-			cmd.emplace_back("WITHSCORES");
-		}
+  if (withscores) {
+    cmd.emplace_back("WITHSCORES");
+  }
 
-/**
+  /**
  * limit (optional)
  */
-		if (limit) {
-			cmd.emplace_back("LIMIT");
-			cmd.push_back(std::to_string(offset));
-			cmd.push_back(std::to_string(count));
-		}
+  if (limit) {
+    cmd.emplace_back("LIMIT");
+    cmd.push_back(std::to_string(offset));
+    cmd.push_back(std::to_string(count));
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrank(const std::string &key, const std::string &member, const reply_callback_t &reply_callback) {
-		send({"ZRANK", key, member}, reply_callback);
-		return *this;
-	}
+client&
+client::zrank(const std::string& key, const std::string& member, const reply_callback_t& reply_callback) {
+  send({"ZRANK", key, member}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrem(const std::string &key, const std::vector<std::string> &members,
-	             const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"ZREM", key};
-		cmd.insert(cmd.end(), members.begin(), members.end());
-		send(cmd, reply_callback);
-		return *this;
-	}
+client&
+client::zrem(const std::string& key, const std::vector<std::string>& members,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"ZREM", key};
+  cmd.insert(cmd.end(), members.begin(), members.end());
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zremrangebylex(const std::string &key, int min, int max, const reply_callback_t &reply_callback) {
-		send({"ZREMRANGEBYLEX", key, std::to_string(min), std::to_string(max)}, reply_callback);
-		return *this;
-	}
+client&
+client::zremrangebylex(const std::string& key, int min, int max, const reply_callback_t& reply_callback) {
+  send({"ZREMRANGEBYLEX", key, std::to_string(min), std::to_string(max)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zremrangebylex(const std::string &key, double min, double max, const reply_callback_t &reply_callback) {
-		send({"ZREMRANGEBYLEX", key, std::to_string(min), std::to_string(max)}, reply_callback);
-		return *this;
-	}
+client&
+client::zremrangebylex(const std::string& key, double min, double max, const reply_callback_t& reply_callback) {
+  send({"ZREMRANGEBYLEX", key, std::to_string(min), std::to_string(max)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zremrangebylex(const std::string &key, const std::string &min, const std::string &max,
-	                       const reply_callback_t &reply_callback) {
-		send({"ZREMRANGEBYLEX", key, min, max}, reply_callback);
-		return *this;
-	}
+client&
+client::zremrangebylex(const std::string& key, const std::string& min, const std::string& max,
+  const reply_callback_t& reply_callback) {
+  send({"ZREMRANGEBYLEX", key, min, max}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zremrangebyrank(const std::string &key, int start, int stop, const reply_callback_t &reply_callback) {
-		send({"ZREMRANGEBYRANK", key, std::to_string(start), std::to_string(stop)}, reply_callback);
-		return *this;
-	}
+client&
+client::zremrangebyrank(const std::string& key, int start, int stop, const reply_callback_t& reply_callback) {
+  send({"ZREMRANGEBYRANK", key, std::to_string(start), std::to_string(stop)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zremrangebyrank(const std::string &key, double start, double stop, const reply_callback_t &reply_callback) {
-		send({"ZREMRANGEBYRANK", key, std::to_string(start), std::to_string(stop)}, reply_callback);
-		return *this;
-	}
+client&
+client::zremrangebyrank(const std::string& key, double start, double stop, const reply_callback_t& reply_callback) {
+  send({"ZREMRANGEBYRANK", key, std::to_string(start), std::to_string(stop)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zremrangebyrank(const std::string &key, const std::string &start, const std::string &stop,
-	                        const reply_callback_t &reply_callback) {
-		send({"ZREMRANGEBYRANK", key, start, stop}, reply_callback);
-		return *this;
-	}
+client&
+client::zremrangebyrank(const std::string& key, const std::string& start, const std::string& stop,
+  const reply_callback_t& reply_callback) {
+  send({"ZREMRANGEBYRANK", key, start, stop}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zremrangebyscore(const std::string &key, int min, int max, const reply_callback_t &reply_callback) {
-		send({"ZREMRANGEBYSCORE", key, std::to_string(min), std::to_string(max)}, reply_callback);
-		return *this;
-	}
+client&
+client::zremrangebyscore(const std::string& key, int min, int max, const reply_callback_t& reply_callback) {
+  send({"ZREMRANGEBYSCORE", key, std::to_string(min), std::to_string(max)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zremrangebyscore(const std::string &key, double min, double max, const reply_callback_t &reply_callback) {
-		send({"ZREMRANGEBYSCORE", key, std::to_string(min), std::to_string(max)}, reply_callback);
-		return *this;
-	}
+client&
+client::zremrangebyscore(const std::string& key, double min, double max, const reply_callback_t& reply_callback) {
+  send({"ZREMRANGEBYSCORE", key, std::to_string(min), std::to_string(max)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zremrangebyscore(const std::string &key, const std::string &min, const std::string &max,
-	                         const reply_callback_t &reply_callback) {
-		send({"ZREMRANGEBYSCORE", key, min, max}, reply_callback);
-		return *this;
-	}
+client&
+client::zremrangebyscore(const std::string& key, const std::string& min, const std::string& max,
+  const reply_callback_t& reply_callback) {
+  send({"ZREMRANGEBYSCORE", key, min, max}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrevrange(const std::string &key, int start, int stop, const reply_callback_t &reply_callback) {
-		send({"ZREVRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
-		return *this;
-	}
+client&
+client::zrevrange(const std::string& key, int start, int stop, const reply_callback_t& reply_callback) {
+  send({"ZREVRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrevrange(const std::string &key, int start, int stop, bool withscores,
-	                  const reply_callback_t &reply_callback) {
-		if (withscores)
-			send({"ZREVRANGE", key, std::to_string(start), std::to_string(stop), "WITHSCORES"}, reply_callback);
-		else
-			send({"ZREVRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
-		return *this;
-	}
+client&
+client::zrevrange(const std::string& key, int start, int stop, bool withscores,
+  const reply_callback_t& reply_callback) {
+  if (withscores)
+    send({"ZREVRANGE", key, std::to_string(start), std::to_string(stop), "WITHSCORES"}, reply_callback);
+  else
+    send({"ZREVRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrevrange(const std::string &key, double start, double stop, const reply_callback_t &reply_callback) {
-		send({"ZREVRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
-		return *this;
-	}
+client&
+client::zrevrange(const std::string& key, double start, double stop, const reply_callback_t& reply_callback) {
+  send({"ZREVRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrevrange(const std::string &key, double start, double stop, bool withscores,
-	                  const reply_callback_t &reply_callback) {
-		if (withscores)
-			send({"ZREVRANGE", key, std::to_string(start), std::to_string(stop), "WITHSCORES"}, reply_callback);
-		else
-			send({"ZREVRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
-		return *this;
-	}
+client&
+client::zrevrange(const std::string& key, double start, double stop, bool withscores,
+  const reply_callback_t& reply_callback) {
+  if (withscores)
+    send({"ZREVRANGE", key, std::to_string(start), std::to_string(stop), "WITHSCORES"}, reply_callback);
+  else
+    send({"ZREVRANGE", key, std::to_string(start), std::to_string(stop)}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrevrange(const std::string &key, const std::string &start, const std::string &stop,
-	                  const reply_callback_t &reply_callback) {
-		send({"ZREVRANGE", key, start, stop}, reply_callback);
-		return *this;
-	}
+client&
+client::zrevrange(const std::string& key, const std::string& start, const std::string& stop,
+  const reply_callback_t& reply_callback) {
+  send({"ZREVRANGE", key, start, stop}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrevrange(const std::string &key, const std::string &start, const std::string &stop, bool withscores,
-	                  const reply_callback_t &reply_callback) {
-		if (withscores)
-			send({"ZREVRANGE", key, start, stop, "WITHSCORES"}, reply_callback);
-		else
-			send({"ZREVRANGE", key, start, stop}, reply_callback);
-		return *this;
-	}
+client&
+client::zrevrange(const std::string& key, const std::string& start, const std::string& stop, bool withscores,
+  const reply_callback_t& reply_callback) {
+  if (withscores)
+    send({"ZREVRANGE", key, start, stop, "WITHSCORES"}, reply_callback);
+  else
+    send({"ZREVRANGE", key, start, stop}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrevrangebylex(const std::string &key, int max, int min, const reply_callback_t &reply_callback) {
-		return zrevrangebylex(key, std::to_string(max), std::to_string(min), false, 0, 0, false, reply_callback);
-	}
+client&
+client::zrevrangebylex(const std::string& key, int max, int min, const reply_callback_t& reply_callback) {
+  return zrevrangebylex(key, std::to_string(max), std::to_string(min), false, 0, 0, false, reply_callback);
+}
 
-	client &
-	client::zrevrangebylex(const std::string &key, int max, int min, bool withscores,
-	                       const reply_callback_t &reply_callback) {
-		return zrevrangebylex(key, std::to_string(max), std::to_string(min), false, 0, 0, withscores, reply_callback);
-	}
+client&
+client::zrevrangebylex(const std::string& key, int max, int min, bool withscores,
+  const reply_callback_t& reply_callback) {
+  return zrevrangebylex(key, std::to_string(max), std::to_string(min), false, 0, 0, withscores, reply_callback);
+}
 
-	client &
-	client::zrevrangebylex(const std::string &key, double max, double min, const reply_callback_t &reply_callback) {
-		return zrevrangebylex(key, std::to_string(max), std::to_string(min), false, 0, 0, false, reply_callback);
-	}
+client&
+client::zrevrangebylex(const std::string& key, double max, double min, const reply_callback_t& reply_callback) {
+  return zrevrangebylex(key, std::to_string(max), std::to_string(min), false, 0, 0, false, reply_callback);
+}
 
-	client &
-	client::zrevrangebylex(const std::string &key, double max, double min, bool withscores,
-	                       const reply_callback_t &reply_callback) {
-		return zrevrangebylex(key, std::to_string(max), std::to_string(min), false, 0, 0, withscores, reply_callback);
-	}
+client&
+client::zrevrangebylex(const std::string& key, double max, double min, bool withscores,
+  const reply_callback_t& reply_callback) {
+  return zrevrangebylex(key, std::to_string(max), std::to_string(min), false, 0, 0, withscores, reply_callback);
+}
 
-	client &
-	client::zrevrangebylex(const std::string &key, const std::string &max, const std::string &min,
-	                       const reply_callback_t &reply_callback) {
-		return zrevrangebylex(key, max, min, false, 0, 0, false, reply_callback);
-	}
+client&
+client::zrevrangebylex(const std::string& key, const std::string& max, const std::string& min,
+  const reply_callback_t& reply_callback) {
+  return zrevrangebylex(key, max, min, false, 0, 0, false, reply_callback);
+}
 
-	client &
-	client::zrevrangebylex(const std::string &key, const std::string &max, const std::string &min, bool withscores,
-	                       const reply_callback_t &reply_callback) {
-		return zrevrangebylex(key, max, min, false, 0, 0, withscores, reply_callback);
-	}
+client&
+client::zrevrangebylex(const std::string& key, const std::string& max, const std::string& min, bool withscores,
+  const reply_callback_t& reply_callback) {
+  return zrevrangebylex(key, max, min, false, 0, 0, withscores, reply_callback);
+}
 
-	client &
-	client::zrevrangebylex(const std::string &key, int max, int min, std::size_t offset, std::size_t count,
-	                       const reply_callback_t &reply_callback) {
-		return zrevrangebylex(key, std::to_string(max), std::to_string(min), true, offset, count, false, reply_callback);
-	}
+client&
+client::zrevrangebylex(const std::string& key, int max, int min, std::size_t offset, std::size_t count,
+  const reply_callback_t& reply_callback) {
+  return zrevrangebylex(key, std::to_string(max), std::to_string(min), true, offset, count, false, reply_callback);
+}
 
-	client &
-	client::zrevrangebylex(const std::string &key, int max, int min, std::size_t offset, std::size_t count,
-	                       bool withscores, const reply_callback_t &reply_callback) {
-		return zrevrangebylex(key, std::to_string(max), std::to_string(min), true, offset, count, withscores,
-		                      reply_callback);
-	}
+client&
+client::zrevrangebylex(const std::string& key, int max, int min, std::size_t offset, std::size_t count,
+  bool withscores, const reply_callback_t& reply_callback) {
+  return zrevrangebylex(key, std::to_string(max), std::to_string(min), true, offset, count, withscores,
+    reply_callback);
+}
 
-	client &
-	client::zrevrangebylex(const std::string &key, double max, double min, std::size_t offset, std::size_t count,
-	                       const reply_callback_t &reply_callback) {
-		return zrevrangebylex(key, std::to_string(max), std::to_string(min), true, offset, count, false, reply_callback);
-	}
+client&
+client::zrevrangebylex(const std::string& key, double max, double min, std::size_t offset, std::size_t count,
+  const reply_callback_t& reply_callback) {
+  return zrevrangebylex(key, std::to_string(max), std::to_string(min), true, offset, count, false, reply_callback);
+}
 
-	client &
-	client::zrevrangebylex(const std::string &key, double max, double min, std::size_t offset, std::size_t count,
-	                       bool withscores, const reply_callback_t &reply_callback) {
-		return zrevrangebylex(key, std::to_string(max), std::to_string(min), true, offset, count, withscores,
-		                      reply_callback);
-	}
+client&
+client::zrevrangebylex(const std::string& key, double max, double min, std::size_t offset, std::size_t count,
+  bool withscores, const reply_callback_t& reply_callback) {
+  return zrevrangebylex(key, std::to_string(max), std::to_string(min), true, offset, count, withscores,
+    reply_callback);
+}
 
-	client &
-	client::zrevrangebylex(const std::string &key, const std::string &max, const std::string &min, std::size_t offset,
-	                       std::size_t count, const reply_callback_t &reply_callback) {
-		return zrevrangebylex(key, max, min, true, offset, count, false, reply_callback);
-	}
+client&
+client::zrevrangebylex(const std::string& key, const std::string& max, const std::string& min, std::size_t offset,
+  std::size_t count, const reply_callback_t& reply_callback) {
+  return zrevrangebylex(key, max, min, true, offset, count, false, reply_callback);
+}
 
-	client &
-	client::zrevrangebylex(const std::string &key, const std::string &max, const std::string &min, std::size_t offset,
-	                       std::size_t count, bool withscores, const reply_callback_t &reply_callback) {
-		return zrevrangebylex(key, max, min, true, offset, count, withscores, reply_callback);
-	}
+client&
+client::zrevrangebylex(const std::string& key, const std::string& max, const std::string& min, std::size_t offset,
+  std::size_t count, bool withscores, const reply_callback_t& reply_callback) {
+  return zrevrangebylex(key, max, min, true, offset, count, withscores, reply_callback);
+}
 
-	client &
-	client::zrevrangebylex(const std::string &key, const std::string &max, const std::string &min, bool limit,
-	                       std::size_t offset, std::size_t count, bool withscores,
-	                       const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"ZREVRANGEBYLEX", key, max, min};
+client&
+client::zrevrangebylex(const std::string& key, const std::string& max, const std::string& min, bool limit,
+  std::size_t offset, std::size_t count, bool withscores,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"ZREVRANGEBYLEX", key, max, min};
 
-/**
+  /**
  * withscores (optional)
  */
-		if (withscores) {
-			cmd.emplace_back("WITHSCORES");
-		}
+  if (withscores) {
+    cmd.emplace_back("WITHSCORES");
+  }
 
-/**
+  /**
  * limit (optional)
  */
-		if (limit) {
-			cmd.emplace_back("LIMIT");
-			cmd.push_back(std::to_string(offset));
-			cmd.push_back(std::to_string(count));
-		}
+  if (limit) {
+    cmd.emplace_back("LIMIT");
+    cmd.push_back(std::to_string(offset));
+    cmd.push_back(std::to_string(count));
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrevrangebyscore(const std::string &key, int max, int min, const reply_callback_t &reply_callback) {
-		return zrevrangebyscore(key, std::to_string(max), std::to_string(min), false, 0, 0, false, reply_callback);
-	}
+client&
+client::zrevrangebyscore(const std::string& key, int max, int min, const reply_callback_t& reply_callback) {
+  return zrevrangebyscore(key, std::to_string(max), std::to_string(min), false, 0, 0, false, reply_callback);
+}
 
-	client &
-	client::zrevrangebyscore(const std::string &key, int max, int min, bool withscores,
-	                         const reply_callback_t &reply_callback) {
-		return zrevrangebyscore(key, std::to_string(max), std::to_string(min), false, 0, 0, withscores, reply_callback);
-	}
+client&
+client::zrevrangebyscore(const std::string& key, int max, int min, bool withscores,
+  const reply_callback_t& reply_callback) {
+  return zrevrangebyscore(key, std::to_string(max), std::to_string(min), false, 0, 0, withscores, reply_callback);
+}
 
-	client &
-	client::zrevrangebyscore(const std::string &key, double max, double min, const reply_callback_t &reply_callback) {
-		return zrevrangebyscore(key, std::to_string(max), std::to_string(min), false, 0, 0, false, reply_callback);
-	}
+client&
+client::zrevrangebyscore(const std::string& key, double max, double min, const reply_callback_t& reply_callback) {
+  return zrevrangebyscore(key, std::to_string(max), std::to_string(min), false, 0, 0, false, reply_callback);
+}
 
-	client &
-	client::zrevrangebyscore(const std::string &key, double max, double min, bool withscores,
-	                         const reply_callback_t &reply_callback) {
-		return zrevrangebyscore(key, std::to_string(max), std::to_string(min), false, 0, 0, withscores, reply_callback);
-	}
+client&
+client::zrevrangebyscore(const std::string& key, double max, double min, bool withscores,
+  const reply_callback_t& reply_callback) {
+  return zrevrangebyscore(key, std::to_string(max), std::to_string(min), false, 0, 0, withscores, reply_callback);
+}
 
-	client &
-	client::zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min,
-	                         const reply_callback_t &reply_callback) {
-		return zrevrangebyscore(key, max, min, false, 0, 0, false, reply_callback);
-	}
+client&
+client::zrevrangebyscore(const std::string& key, const std::string& max, const std::string& min,
+  const reply_callback_t& reply_callback) {
+  return zrevrangebyscore(key, max, min, false, 0, 0, false, reply_callback);
+}
 
-	client &
-	client::zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min, bool withscores,
-	                         const reply_callback_t &reply_callback) {
-		return zrevrangebyscore(key, max, min, false, 0, 0, withscores, reply_callback);
-	}
+client&
+client::zrevrangebyscore(const std::string& key, const std::string& max, const std::string& min, bool withscores,
+  const reply_callback_t& reply_callback) {
+  return zrevrangebyscore(key, max, min, false, 0, 0, withscores, reply_callback);
+}
 
-	client &
-	client::zrevrangebyscore(const std::string &key, int max, int min, std::size_t offset, std::size_t count,
-	                         const reply_callback_t &reply_callback) {
-		return zrevrangebyscore(key, std::to_string(max), std::to_string(min), true, offset, count, false, reply_callback);
-	}
+client&
+client::zrevrangebyscore(const std::string& key, int max, int min, std::size_t offset, std::size_t count,
+  const reply_callback_t& reply_callback) {
+  return zrevrangebyscore(key, std::to_string(max), std::to_string(min), true, offset, count, false, reply_callback);
+}
 
-	client &
-	client::zrevrangebyscore(const std::string &key, int max, int min, std::size_t offset, std::size_t count,
-	                         bool withscores, const reply_callback_t &reply_callback) {
-		return zrevrangebyscore(key, std::to_string(max), std::to_string(min), true, offset, count, withscores,
-		                        reply_callback);
-	}
+client&
+client::zrevrangebyscore(const std::string& key, int max, int min, std::size_t offset, std::size_t count,
+  bool withscores, const reply_callback_t& reply_callback) {
+  return zrevrangebyscore(key, std::to_string(max), std::to_string(min), true, offset, count, withscores,
+    reply_callback);
+}
 
-	client &
-	client::zrevrangebyscore(const std::string &key, double max, double min, std::size_t offset, std::size_t count,
-	                         const reply_callback_t &reply_callback) {
-		return zrevrangebyscore(key, std::to_string(max), std::to_string(min), true, offset, count, false, reply_callback);
-	}
+client&
+client::zrevrangebyscore(const std::string& key, double max, double min, std::size_t offset, std::size_t count,
+  const reply_callback_t& reply_callback) {
+  return zrevrangebyscore(key, std::to_string(max), std::to_string(min), true, offset, count, false, reply_callback);
+}
 
-	client &
-	client::zrevrangebyscore(const std::string &key, double max, double min, std::size_t offset, std::size_t count,
-	                         bool withscores, const reply_callback_t &reply_callback) {
-		return zrevrangebyscore(key, std::to_string(max), std::to_string(min), true, offset, count, withscores,
-		                        reply_callback);
-	}
+client&
+client::zrevrangebyscore(const std::string& key, double max, double min, std::size_t offset, std::size_t count,
+  bool withscores, const reply_callback_t& reply_callback) {
+  return zrevrangebyscore(key, std::to_string(max), std::to_string(min), true, offset, count, withscores,
+    reply_callback);
+}
 
-	client &
-	client::zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min, std::size_t offset,
-	                         std::size_t count, const reply_callback_t &reply_callback) {
-		return zrevrangebyscore(key, max, min, true, offset, count, false, reply_callback);
-	}
+client&
+client::zrevrangebyscore(const std::string& key, const std::string& max, const std::string& min, std::size_t offset,
+  std::size_t count, const reply_callback_t& reply_callback) {
+  return zrevrangebyscore(key, max, min, true, offset, count, false, reply_callback);
+}
 
-	client &
-	client::zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min, std::size_t offset,
-	                         std::size_t count, bool withscores, const reply_callback_t &reply_callback) {
-		return zrevrangebyscore(key, max, min, true, offset, count, withscores, reply_callback);
-	}
+client&
+client::zrevrangebyscore(const std::string& key, const std::string& max, const std::string& min, std::size_t offset,
+  std::size_t count, bool withscores, const reply_callback_t& reply_callback) {
+  return zrevrangebyscore(key, max, min, true, offset, count, withscores, reply_callback);
+}
 
-	client &
-	client::zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min, bool limit,
-	                         std::size_t offset, std::size_t count, bool withscores,
-	                         const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"ZREVRANGEBYSCORE", key, max, min};
+client&
+client::zrevrangebyscore(const std::string& key, const std::string& max, const std::string& min, bool limit,
+  std::size_t offset, std::size_t count, bool withscores,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"ZREVRANGEBYSCORE", key, max, min};
 
-/**
+  /**
  * withscores (optional)
  */
-		if (withscores) {
-			cmd.emplace_back("WITHSCORES");
-		}
+  if (withscores) {
+    cmd.emplace_back("WITHSCORES");
+  }
 
-/**
+  /**
  * limit (optional)
  */
-		if (limit) {
-			cmd.emplace_back("LIMIT");
-			cmd.push_back(std::to_string(offset));
-			cmd.push_back(std::to_string(count));
-		}
+  if (limit) {
+    cmd.emplace_back("LIMIT");
+    cmd.push_back(std::to_string(offset));
+    cmd.push_back(std::to_string(count));
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zrevrank(const std::string &key, const std::string &member, const reply_callback_t &reply_callback) {
-		send({"ZREVRANK", key, member}, reply_callback);
-		return *this;
-	}
+client&
+client::zrevrank(const std::string& key, const std::string& member, const reply_callback_t& reply_callback) {
+  send({"ZREVRANK", key, member}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zscan(const std::string &key, std::size_t cursor, const reply_callback_t &reply_callback) {
-		return zscan(key, cursor, "", 0, reply_callback);
-	}
+client&
+client::zscan(const std::string& key, std::size_t cursor, const reply_callback_t& reply_callback) {
+  return zscan(key, cursor, "", 0, reply_callback);
+}
 
-	client &
-	client::zscan(const std::string &key, std::size_t cursor, const std::string &pattern,
-	              const reply_callback_t &reply_callback) {
-		return zscan(key, cursor, pattern, 0, reply_callback);
-	}
+client&
+client::zscan(const std::string& key, std::size_t cursor, const std::string& pattern,
+  const reply_callback_t& reply_callback) {
+  return zscan(key, cursor, pattern, 0, reply_callback);
+}
 
-	client &
-	client::zscan(const std::string &key, std::size_t cursor, std::size_t count, const reply_callback_t &reply_callback) {
-		return zscan(key, cursor, "", count, reply_callback);
-	}
+client&
+client::zscan(const std::string& key, std::size_t cursor, std::size_t count, const reply_callback_t& reply_callback) {
+  return zscan(key, cursor, "", count, reply_callback);
+}
 
-	client &
-	client::zscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count,
-	              const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"ZSCAN", key, std::to_string(cursor)};
+client&
+client::zscan(const std::string& key, std::size_t cursor, const std::string& pattern, std::size_t count,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"ZSCAN", key, std::to_string(cursor)};
 
-		if (!pattern.empty()) {
-			cmd.emplace_back("MATCH");
-			cmd.push_back(pattern);
-		}
+  if (!pattern.empty()) {
+    cmd.emplace_back("MATCH");
+    cmd.push_back(pattern);
+  }
 
-		if (count > 0) {
-			cmd.emplace_back("COUNT");
-			cmd.push_back(std::to_string(count));
-		}
+  if (count > 0) {
+    cmd.emplace_back("COUNT");
+    cmd.push_back(std::to_string(count));
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zscore(const std::string &key, const std::string &member, const reply_callback_t &reply_callback) {
-		send({"ZSCORE", key, member}, reply_callback);
-		return *this;
-	}
+client&
+client::zscore(const std::string& key, const std::string& member, const reply_callback_t& reply_callback) {
+  send({"ZSCORE", key, member}, reply_callback);
+  return *this;
+}
 
-	client &
-	client::zunionstore(const std::string &destination, std::size_t numkeys, const std::vector<std::string> &keys,
-	                    const std::vector<std::size_t> weights, aggregate_method method,
-	                    const reply_callback_t &reply_callback) {
-		std::vector<std::string> cmd = {"ZUNIONSTORE", destination, std::to_string(numkeys)};
+client&
+client::zunionstore(const std::string& destination, std::size_t numkeys, const std::vector<std::string>& keys,
+  const std::vector<std::size_t> weights, aggregate_method method,
+  const reply_callback_t& reply_callback) {
+  std::vector<std::string> cmd = {"ZUNIONSTORE", destination, std::to_string(numkeys)};
 
-/**
+  /**
  * keys
  */
-		for (const auto &key : keys) {
-			cmd.push_back(key);
-		}
+  for (const auto& key : keys) {
+    cmd.push_back(key);
+  }
 
-/**
+  /**
  * weights (optional)
  */
-		if (!weights.empty()) {
-			cmd.emplace_back("WEIGHTS");
+  if (!weights.empty()) {
+    cmd.emplace_back("WEIGHTS");
 
-			for (auto weight : weights) {
-				cmd.push_back(std::to_string(weight));
-			}
-		}
+    for (auto weight : weights) {
+      cmd.push_back(std::to_string(weight));
+    }
+  }
 
-/**
+  /**
  * aggregate method
  */
-		if (method != aggregate_method::server_default) {
-			cmd.emplace_back("AGGREGATE");
-			cmd.push_back(aggregate_method_to_string(method));
-		}
+  if (method != aggregate_method::server_default) {
+    cmd.emplace_back("AGGREGATE");
+    cmd.push_back(aggregate_method_to_string(method));
+  }
 
-		send(cmd, reply_callback);
-		return *this;
-	}
+  send(cmd, reply_callback);
+  return *this;
+}
 
 /**
  * Redis Commands
  * std::future-based
  */
 
-	std::future<reply>
-	client::exec_cmd(const std::function<client &(const reply_callback_t &)> &f) {
-		auto prms = std::make_shared<std::promise<reply>>();
-
-		f([prms](reply &reply) {
-				prms->set_value(reply);
-		});
-
-		return prms->get_future();
-	}
-
-	std::future<reply>
-	client::send(const std::vector<std::string> &redis_cmd) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return send(redis_cmd, cb); });
-	}
-
-	std::future<reply>
-	client::append(const std::string &key, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return append(key, value, cb); });
-	}
-
-	std::future<reply>
-	client::auth(const std::string &password) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return auth(password, cb); });
-	}
-
-	std::future<reply>
-	client::bgrewriteaof() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bgrewriteaof(cb); });
-	}
-
-	std::future<reply>
-	client::bgsave() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bgsave(cb); });
-	}
-
-	std::future<reply>
-	client::bitcount(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bitcount(key, cb); });
-	}
-
-	std::future<reply>
-	client::bitcount(const std::string &key, int start, int end) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bitcount(key, start, end, cb); });
-	}
-
-	std::future<reply>
-	client::bitfield(const std::string &key, const std::vector<bitfield_operation> &operations) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bitfield(key, operations, cb); });
-	}
-
-	std::future<reply>
-	client::bitop(const std::string &operation, const std::string &destkey, const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bitop(operation, destkey, keys, cb); });
-	}
-
-	std::future<reply>
-	client::bitpos(const std::string &key, int bit) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bitpos(key, bit, cb); });
-	}
-
-	std::future<reply>
-	client::bitpos(const std::string &key, int bit, int start) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bitpos(key, bit, start, cb); });
-	}
-
-	std::future<reply>
-	client::bitpos(const std::string &key, int bit, int start, int end) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return bitpos(key, bit, start, end, cb); });
-	}
-
-	std::future<reply>
-	client::blpop(const std::vector<std::string> &keys, int timeout) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return blpop(keys, timeout, cb); });
-	}
-
-	std::future<reply>
-	client::brpop(const std::vector<std::string> &keys, int timeout) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return brpop(keys, timeout, cb); });
-	}
-
-	std::future<reply>
-	client::brpoplpush(const std::string &src, const std::string &dst, int timeout) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return brpoplpush(src, dst, timeout, cb); });
-	}
-
-	std::future<reply>
-	client::bzpopmin(const std::vector<std::string>& keys, int timeout) {
-		return exec_cmd([=](const reply_callback_t& cb) -> client& { return bzpopmin(keys, timeout, cb); });
-	}
-
-	std::future<reply>
-	client::bzpopmax(const std::vector<std::string>& keys, int timeout) {
-		return exec_cmd([=](const reply_callback_t& cb) -> client& { return bzpopmax(keys, timeout, cb); });
-	}
-
-	std::future<reply>
-	client::client_id() {
-		return exec_cmd([=](const reply_callback_t& cb) -> client& { return client_id(cb); });
-	}
-
-	std::future<reply>
-	client::client_list() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return client_list(cb); });
-	}
-
-	std::future<reply>
-	client::client_getname() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return client_getname(cb); });
-	}
-
-	std::future<reply>
-	client::client_pause(int timeout) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return client_pause(timeout, cb); });
-	}
-
-	std::future<reply>
-	client::client_reply(const std::string &mode) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return client_reply(mode, cb); });
-	}
-
-	std::future<reply>
-	client::client_setname(const std::string &name) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return client_setname(name, cb); });
-	}
-
-	std::future<reply>
-	client::client_unblock(int id, bool witherror) {
-		return exec_cmd([=](const reply_callback_t& cb) -> client& { return client_unblock(id, witherror, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_addslots(const std::vector<std::string> &p_slots) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_addslots(p_slots, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_count_failure_reports(const std::string &node_id) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_count_failure_reports(node_id, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_countkeysinslot(const std::string &slot) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_countkeysinslot(slot, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_delslots(const std::vector<std::string> &p_slots) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_delslots(p_slots, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_failover() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_failover(cb); });
-	}
-
-	std::future<reply>
-	client::cluster_failover(const std::string &mode) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_failover(mode, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_forget(const std::string &node_id) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_forget(node_id, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_getkeysinslot(const std::string &slot, int count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_getkeysinslot(slot, count, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_info() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_info(cb); });
-	}
-
-	std::future<reply>
-	client::cluster_keyslot(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_keyslot(key, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_meet(const std::string &ip, int port) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_meet(ip, port, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_nodes() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_nodes(cb); });
-	}
-
-	std::future<reply>
-	client::cluster_replicate(const std::string &node_id) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_replicate(node_id, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_reset(const std::string &mode) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_reset(mode, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_saveconfig() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_saveconfig(cb); });
-	}
-
-	std::future<reply>
-	client::cluster_set_config_epoch(const std::string &epoch) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_set_config_epoch(epoch, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_setslot(const std::string &slot, const std::string &mode) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_setslot(slot, mode, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_setslot(const std::string &slot, const std::string &mode, const std::string &node_id) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_setslot(slot, mode, node_id, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_slaves(const std::string &node_id) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_slaves(node_id, cb); });
-	}
-
-	std::future<reply>
-	client::cluster_slots() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return cluster_slots(cb); });
-	}
-
-	std::future<reply>
-	client::command() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return command(cb); });
-	}
-
-	std::future<reply>
-	client::command_count() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return command_count(cb); });
-	}
-
-	std::future<reply>
-	client::command_getkeys() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return command_getkeys(cb); });
-	}
-
-	std::future<reply>
-	client::command_info(const std::vector<std::string> &command_name) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return command_info(command_name, cb); });
-	}
-
-	std::future<reply>
-	client::config_get(const std::string &param) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return config_get(param, cb); });
-	}
-
-	std::future<reply>
-	client::config_rewrite() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return config_rewrite(cb); });
-	}
-
-	std::future<reply>
-	client::config_set(const std::string &param, const std::string &val) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return config_set(param, val, cb); });
-	}
-
-	std::future<reply>
-	client::config_resetstat() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return config_resetstat(cb); });
-	}
-
-	std::future<reply>
-	client::dbsize() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return dbsize(cb); });
-	}
-
-	std::future<reply>
-	client::debug_object(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return debug_object(key, cb); });
-	}
-
-	std::future<reply>
-	client::debug_segfault() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return debug_segfault(cb); });
-	}
-
-	std::future<reply>
-	client::decr(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return decr(key, cb); });
-	}
-
-	std::future<reply>
-	client::decrby(const std::string &key, int val) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return decrby(key, val, cb); });
-	}
-
-	std::future<reply>
-	client::del(const std::vector<std::string> &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return del(key, cb); });
-	}
-
-	std::future<reply>
-	client::discard() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return discard(cb); });
-	}
-
-	std::future<reply>
-	client::dump(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return dump(key, cb); });
-	}
-
-	std::future<reply>
-	client::echo(const std::string &msg) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return echo(msg, cb); });
-	}
-
-	std::future<reply>
-	client::eval(const std::string &script, int numkeys, const std::vector<std::string> &keys,
-	             const std::vector<std::string> &args) {
-		(void) numkeys;
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return eval(script, keys, args, cb); });
-	}
-
-	std::future<reply>
-	client::eval(const std::string &script, const std::vector<std::string> &keys,
-	             const std::vector<std::string> &args) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return eval(script, keys, args, cb); });
-	}
-
-	std::future<reply>
-	client::evalsha(const std::string &sha1, const std::vector<std::string> &keys,
-	                const std::vector<std::string> &args) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return evalsha(sha1, keys, args, cb); });
-	}
-
-	std::future<reply>
-	client::evalsha(const std::string &sha1, int numkeys, const std::vector<std::string> &keys,
-	                const std::vector<std::string> &args) {
-		(void) numkeys;
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return evalsha(sha1, keys, args, cb); });
-	}
-
-	std::future<reply>
-	client::exec() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return exec(cb); });
-	}
-
-	std::future<reply>
-	client::exists(const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return exists(keys, cb); });
-	}
-
-	std::future<reply>
-	client::expire(const std::string &key, int seconds) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return expire(key, seconds, cb); });
-	}
-
-	std::future<reply>
-	client::expireat(const std::string &key, int timestamp) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return expireat(key, timestamp, cb); });
-	}
-
-	std::future<reply>
-	client::flushall() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return flushall(cb); });
-	}
-
-	std::future<reply>
-	client::flushdb() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return flushdb(cb); });
-	}
-
-	std::future<reply>
-	client::geoadd(const std::string &key,
-	               const std::vector<std::tuple<std::string, std::string, std::string>> &long_lat_memb) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return geoadd(key, long_lat_memb, cb); });
-	}
-
-	std::future<reply>
-	client::geohash(const std::string &key, const std::vector<std::string> &members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return geohash(key, members, cb); });
-	}
-
-	std::future<reply>
-	client::geopos(const std::string &key, const std::vector<std::string> &members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return geopos(key, members, cb); });
-	}
-
-	std::future<reply>
-	client::geodist(const std::string &key, const std::string &member_1, const std::string &member_2,
-	                const std::string &unit) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return geodist(key, member_1, member_2, unit, cb); });
-	}
-
-	std::future<reply>
-	client::georadius(const std::string &key, double longitude, double latitude, double radius, geo_unit unit,
-	                  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
-	                  const std::string &store_key, const std::string &storedist_key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return georadius(key, longitude, latitude, radius, unit, with_coord, with_dist, with_hash, asc_order, count,
-				                 store_key, storedist_key, cb);
-		});
-	}
-
-	std::future<reply>
-	client::georadiusbymember(const std::string &key, const std::string &member, double radius, geo_unit unit,
-	                          bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
-	                          const std::string &store_key, const std::string &storedist_key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return georadiusbymember(key, member, radius, unit, with_coord, with_dist, with_hash, asc_order, count,
-				                         store_key, storedist_key, cb);
-		});
-	}
-
-	std::future<reply>
-	client::get(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return get(key, cb); });
-	}
-
-	std::future<reply>
-	client::getbit(const std::string &key, int offset) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return getbit(key, offset, cb); });
-	}
-
-	std::future<reply>
-	client::getrange(const std::string &key, int start, int end) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return getrange(key, start, end, cb); });
-	}
-
-	std::future<reply>
-	client::getset(const std::string &key, const std::string &val) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return getset(key, val, cb); });
-	}
-
-	std::future<reply>
-	client::hdel(const std::string &key, const std::vector<std::string> &fields) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hdel(key, fields, cb); });
-	}
-
-	std::future<reply>
-	client::hexists(const std::string &key, const std::string &field) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hexists(key, field, cb); });
-	}
-
-	std::future<reply>
-	client::hget(const std::string &key, const std::string &field) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hget(key, field, cb); });
-	}
-
-	std::future<reply>
-	client::hgetall(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hgetall(key, cb); });
-	}
-
-	std::future<reply>
-	client::hincrby(const std::string &key, const std::string &field, int incr) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hincrby(key, field, incr, cb); });
-	}
-
-	std::future<reply>
-	client::hincrbyfloat(const std::string &key, const std::string &field, float incr) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hincrbyfloat(key, field, incr, cb); });
-	}
-
-	std::future<reply>
-	client::hkeys(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hkeys(key, cb); });
-	}
-
-	std::future<reply>
-	client::hlen(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hlen(key, cb); });
-	}
-
-	std::future<reply>
-	client::hmget(const std::string &key, const std::vector<std::string> &fields) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hmget(key, fields, cb); });
-	}
-
-	std::future<reply>
-	client::hmset(const std::string &key, const std::vector<std::pair<std::string, std::string>> &field_val) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hmset(key, field_val, cb); });
-	}
-
-	std::future<reply>
-	client::hscan(const std::string &key, std::size_t cursor) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hscan(key, cursor, cb); });
-	}
-
-	std::future<reply>
-	client::hscan(const std::string &key, std::size_t cursor, const std::string &pattern) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hscan(key, cursor, pattern, cb); });
-	}
-
-	std::future<reply>
-	client::hscan(const std::string &key, std::size_t cursor, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hscan(key, cursor, count, cb); });
-	}
-
-	std::future<reply>
-	client::hscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hscan(key, cursor, pattern, count, cb); });
-	}
-
-	std::future<reply>
-	client::hset(const std::string &key, const std::string &field, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hset(key, field, value, cb); });
-	}
-
-	std::future<reply>
-	client::hsetnx(const std::string &key, const std::string &field, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hsetnx(key, field, value, cb); });
-	}
-
-	std::future<reply>
-	client::hstrlen(const std::string &key, const std::string &field) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hstrlen(key, field, cb); });
-	}
-
-	std::future<reply>
-	client::hvals(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return hvals(key, cb); });
-	}
-
-	std::future<reply>
-	client::incr(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return incr(key, cb); });
-	}
-
-	std::future<reply>
-	client::incrby(const std::string &key, int incr) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return incrby(key, incr, cb); });
-	}
-
-	std::future<reply>
-	client::incrbyfloat(const std::string &key, float incr) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return incrbyfloat(key, incr, cb); });
-	}
-
-	std::future<reply>
-	client::info(const std::string &section) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return info(section, cb); });
-	}
-
-	std::future<reply>
-	client::keys(const std::string &pattern) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return keys(pattern, cb); });
-	}
-
-	std::future<reply>
-	client::lastsave() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lastsave(cb); });
-	}
-
-	std::future<reply>
-	client::lindex(const std::string &key, int index) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lindex(key, index, cb); });
-	}
-
-	std::future<reply>
-	client::linsert(const std::string &key, const std::string &before_after, const std::string &pivot,
-	                const std::string &value) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return linsert(key, before_after, pivot, value, cb); });
-	}
-
-	std::future<reply>
-	client::llen(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return llen(key, cb); });
-	}
-
-	std::future<reply>
-	client::lpop(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lpop(key, cb); });
-	}
-
-	std::future<reply>
-	client::lpush(const std::string &key, const std::vector<std::string> &values) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lpush(key, values, cb); });
-	}
-
-	std::future<reply>
-	client::lpushx(const std::string &key, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lpushx(key, value, cb); });
-	}
-
-	std::future<reply>
-	client::lrange(const std::string &key, int start, int stop) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lrange(key, start, stop, cb); });
-	}
-
-	std::future<reply>
-	client::lrem(const std::string &key, int count, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lrem(key, count, value, cb); });
-	}
-
-	std::future<reply>
-	client::lset(const std::string &key, int index, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return lset(key, index, value, cb); });
-	}
-
-	std::future<reply>
-	client::ltrim(const std::string &key, int start, int stop) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return ltrim(key, start, stop, cb); });
-	}
-
-	std::future<reply>
-	client::mget(const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return mget(keys, cb); });
-	}
-
-	std::future<reply>
-	client::migrate(const std::string &host, int port, const std::string &key, const std::string &dest_db, int timeout,
-	                bool copy, bool replace, const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return migrate(host, port, key, dest_db, timeout, copy, replace, keys, cb);
-		});
-	}
-
-	std::future<reply>
-	client::monitor() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return monitor(cb); });
-	}
-
-	std::future<reply>
-	client::move(const std::string &key, const std::string &db) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return move(key, db, cb); });
-	}
-
-	std::future<reply>
-	client::mset(const std::vector<std::pair<std::string, std::string>> &key_vals) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return mset(key_vals, cb); });
-	}
-
-	std::future<reply>
-	client::msetnx(const std::vector<std::pair<std::string, std::string>> &key_vals) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return msetnx(key_vals, cb); });
-	}
-
-	std::future<reply>
-	client::multi() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return multi(cb); });
-	}
-
-	std::future<reply>
-	client::object(const std::string &subcommand, const std::vector<std::string> &args) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return object(subcommand, args, cb); });
-	}
-
-	std::future<reply>
-	client::persist(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return persist(key, cb); });
-	}
-
-	std::future<reply>
-	client::pexpire(const std::string &key, int ms) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return pexpire(key, ms, cb); });
-	}
-
-	std::future<reply>
-	client::pexpireat(const std::string &key, int ms_timestamp) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return pexpireat(key, ms_timestamp, cb); });
-	}
-
-	std::future<reply>
-	client::pfadd(const std::string &key, const std::vector<std::string> &elements) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return pfadd(key, elements, cb); });
-	}
-
-	std::future<reply>
-	client::pfcount(const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return pfcount(keys, cb); });
-	}
-
-	std::future<reply>
-	client::pfmerge(const std::string &destkey, const std::vector<std::string> &sourcekeys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return pfmerge(destkey, sourcekeys, cb); });
-	}
-
-	std::future<reply>
-	client::ping() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return ping(cb); });
-	}
-
-	std::future<reply>
-	client::ping(const std::string &message) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return ping(message, cb); });
-	}
-
-	std::future<reply>
-	client::psetex(const std::string &key, int64_t ms, const std::string &val) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return psetex(key, ms, val, cb); });
-	}
-
-	std::future<reply>
-	client::publish(const std::string &channel, const std::string &message) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return publish(channel, message, cb); });
-	}
-
-	std::future<reply>
-	client::pubsub(const std::string &subcommand, const std::vector<std::string> &args) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return pubsub(subcommand, args, cb); });
-	}
-
-	std::future<reply>
-	client::pttl(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return pttl(key, cb); });
-	}
-
-	std::future<reply>
-	client::quit() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return quit(cb); });
-	}
-
-	std::future<reply>
-	client::randomkey() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return randomkey(cb); });
-	}
-
-	std::future<reply>
-	client::readonly() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return readonly(cb); });
-	}
-
-	std::future<reply>
-	client::readwrite() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return readwrite(cb); });
-	}
-
-	std::future<reply>
-	client::rename(const std::string &key, const std::string &newkey) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return rename(key, newkey, cb); });
-	}
-
-	std::future<reply>
-	client::renamenx(const std::string &key, const std::string &newkey) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return renamenx(key, newkey, cb); });
-	}
-
-	std::future<reply>
-	client::restore(const std::string &key, int ttl, const std::string &serialized_value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return restore(key, ttl, serialized_value, cb); });
-	}
-
-	std::future<reply>
-	client::restore(const std::string &key, int ttl, const std::string &serialized_value, const std::string &replace) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return restore(key, ttl, serialized_value, replace, cb); });
-	}
-
-	std::future<reply>
-	client::role() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return role(cb); });
-	}
-
-	std::future<reply>
-	client::rpop(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return rpop(key, cb); });
-	}
-
-	std::future<reply>
-	client::rpoplpush(const std::string &src, const std::string &dst) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return rpoplpush(src, dst, cb); });
-	}
-
-	std::future<reply>
-	client::rpush(const std::string &key, const std::vector<std::string> &values) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return rpush(key, values, cb); });
-	}
-
-	std::future<reply>
-	client::rpushx(const std::string &key, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return rpushx(key, value, cb); });
-	}
-
-	std::future<reply>
-	client::sadd(const std::string &key, const std::vector<std::string> &members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sadd(key, members, cb); });
-	}
-
-	std::future<reply>
-	client::scan(std::size_t cursor) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return scan(cursor, cb); });
-	}
-
-	std::future<reply>
-	client::scan(std::size_t cursor, const std::string &pattern) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return scan(cursor, pattern, cb); });
-	}
-
-	std::future<reply>
-	client::scan(std::size_t cursor, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return scan(cursor, count, cb); });
-	}
-
-	std::future<reply>
-	client::scan(std::size_t cursor, const std::string &pattern, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return scan(cursor, pattern, count, cb); });
-	}
-
-	std::future<reply>
-	client::save() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return save(cb); });
-	}
-
-	std::future<reply>
-	client::scard(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return scard(key, cb); });
-	}
-
-	std::future<reply>
-	client::script_debug(const std::string &mode) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return script_debug(mode, cb); });
-	}
-
-	std::future<reply>
-	client::script_exists(const std::vector<std::string> &scripts) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return script_exists(scripts, cb); });
-	}
-
-	std::future<reply>
-	client::script_flush() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return script_flush(cb); });
-	}
-
-	std::future<reply>
-	client::script_kill() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return script_kill(cb); });
-	}
-
-	std::future<reply>
-	client::script_load(const std::string &script) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return script_load(script, cb); });
-	}
-
-	std::future<reply>
-	client::sdiff(const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sdiff(keys, cb); });
-	}
-
-	std::future<reply>
-	client::sdiffstore(const std::string &dst, const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sdiffstore(dst, keys, cb); });
-	}
-
-	std::future<reply>
-	client::select(int index) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return select(index, cb); });
-	}
-
-	std::future<reply>
-	client::set(const std::string &key, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return set(key, value, cb); });
-	}
-
-	std::future<reply>
-	client::set_advanced(const std::string &key, const std::string &value, bool ex, int ex_sec, bool px, int px_milli,
-	                     bool nx, bool xx) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return set_advanced(key, value, ex, ex_sec, px, px_milli, nx, xx, cb);
-		});
-	}
-
-	std::future<reply>
-	client::setbit_(const std::string &key, int offset, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return setbit_(key, offset, value, cb); });
-	}
-
-	std::future<reply>
-	client::setex(const std::string &key, int64_t seconds, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return setex(key, seconds, value, cb); });
-	}
-
-	std::future<reply>
-	client::setnx(const std::string &key, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return setnx(key, value, cb); });
-	}
-
-	std::future<reply>
-	client::setrange(const std::string &key, int offset, const std::string &value) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return setrange(key, offset, value, cb); });
-	}
-
-	std::future<reply>
-	client::shutdown() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return shutdown(cb); });
-	}
-
-	std::future<reply>
-	client::shutdown(const std::string &save) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return shutdown(save, cb); });
-	}
-
-	std::future<reply>
-	client::sinter(const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sinter(keys, cb); });
-	}
-
-	std::future<reply>
-	client::sinterstore(const std::string &dst, const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sinterstore(dst, keys, cb); });
-	}
-
-	std::future<reply>
-	client::sismember(const std::string &key, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sismember(key, member, cb); });
-	}
-
-	std::future<reply>
-	client::slaveof(const std::string &host, int port) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return slaveof(host, port, cb); });
-	}
-
-	std::future<reply>
-	client::slowlog(const std::string &subcommand) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return slowlog(subcommand, cb); });
-	}
-
-	std::future<reply>
-	client::slowlog(const std::string &subcommand, const std::string &argument) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return slowlog(subcommand, argument, cb); });
-	}
-
-	std::future<reply>
-	client::smembers(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return smembers(key, cb); });
-	}
-
-	std::future<reply>
-	client::smove(const std::string &src, const std::string &dst, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return smove(src, dst, member, cb); });
-	}
-
-	std::future<reply>
-	client::sort(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sort(key, cb); });
-	}
-
-	std::future<reply>
-	client::sort(const std::string &key, const std::vector<std::string> &get_patterns, bool asc_order, bool alpha) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return sort(key, get_patterns, asc_order, alpha, cb); });
-	}
-
-	std::future<reply>
-	client::sort(const std::string &key, std::size_t offset, std::size_t count,
-	             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return sort(key, offset, count, get_patterns, asc_order, alpha, cb);
-		});
-	}
-
-	std::future<reply>
-	client::sort(const std::string &key, const std::string &by_pattern, const std::vector<std::string> &get_patterns,
-	             bool asc_order, bool alpha) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return sort(key, by_pattern, get_patterns, asc_order, alpha, cb);
-		});
-	}
-
-	std::future<reply>
-	client::sort(const std::string &key, const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
-	             const std::string &store_dest) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return sort(key, get_patterns, asc_order, alpha, store_dest, cb);
-		});
-	}
-
-	std::future<reply>
-	client::sort(const std::string &key, std::size_t offset, std::size_t count,
-	             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
-	             const std::string &store_dest) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return sort(key, offset, count, get_patterns, asc_order, alpha, store_dest, cb);
-		});
-	}
-
-	std::future<reply>
-	client::sort(const std::string &key, const std::string &by_pattern, const std::vector<std::string> &get_patterns,
-	             bool asc_order, bool alpha, const std::string &store_dest) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return sort(key, by_pattern, get_patterns, asc_order, alpha, store_dest, cb);
-		});
-	}
-
-	std::future<reply>
-	client::sort(const std::string &key, const std::string &by_pattern, std::size_t offset, std::size_t count,
-	             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return sort(key, by_pattern, offset, count, get_patterns, asc_order, alpha, cb);
-		});
-	}
-
-	std::future<reply>
-	client::sort(const std::string &key, const std::string &by_pattern, std::size_t offset, std::size_t count,
-	             const std::vector<std::string> &get_patterns, bool asc_order, bool alpha,
-	             const std::string &store_dest) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return sort(key, by_pattern, offset, count, get_patterns, asc_order, alpha, store_dest, cb);
-		});
-	}
-
-	std::future<reply>
-	client::spop(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return spop(key, cb); });
-	}
-
-	std::future<reply>
-	client::spop(const std::string &key, int count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return spop(key, count, cb); });
-	}
-
-	std::future<reply>
-	client::srandmember(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return srandmember(key, cb); });
-	}
-
-	std::future<reply>
-	client::srandmember(const std::string &key, int count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return srandmember(key, count, cb); });
-	}
-
-	std::future<reply>
-	client::srem(const std::string &key, const std::vector<std::string> &members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return srem(key, members, cb); });
-	}
-
-	std::future<reply>
-	client::sscan(const std::string &key, std::size_t cursor) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sscan(key, cursor, cb); });
-	}
-
-	std::future<reply>
-	client::sscan(const std::string &key, std::size_t cursor, const std::string &pattern) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sscan(key, cursor, pattern, cb); });
-	}
-
-	std::future<reply>
-	client::sscan(const std::string &key, std::size_t cursor, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sscan(key, cursor, count, cb); });
-	}
-
-	std::future<reply>
-	client::sscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sscan(key, cursor, pattern, count, cb); });
-	}
-
-	std::future<reply>
-	client::strlen(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return strlen(key, cb); });
-	}
-
-	std::future<reply>
-	client::sunion(const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sunion(keys, cb); });
-	}
-
-	std::future<reply>
-	client::sunionstore(const std::string &dst, const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sunionstore(dst, keys, cb); });
-	}
-
-	std::future<reply>
-	client::sync() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return sync(cb); });
-	}
-
-	std::future<reply>
-	client::time() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return time(cb); });
-	}
-
-	std::future<reply>
-	client::ttl(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return ttl(key, cb); });
-	}
-
-	std::future<reply>
-	client::type(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return type(key, cb); });
-	}
-
-	std::future<reply>
-	client::unwatch() {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return unwatch(cb); });
-	}
-
-	std::future<reply>
-	client::wait(int numslaves, int timeout) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return wait(numslaves, timeout, cb); });
-	}
-
-	std::future<reply>
-	client::watch(const std::vector<std::string> &keys) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return watch(keys, cb); });
-	}
-
-	std::future<reply>
-	client::xack(const std::string &key, const std::string &group, const std::vector<std::string> &id_members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return xack(key, group, id_members, cb); });
-	}
-
-	std::future<reply>
-	client::xadd(const std::string &key, const std::string &id,
-	             const std::multimap<std::string, std::string> &field_members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xadd(key, id, field_members, cb);
-		});
-	}
-
-	std::future<reply> client::xclaim(const std::string &key, const std::string &group, const std::string &consumer,
-	                                  const int &min_idle_time, const std::vector<std::string> &id_members, const xclaim_options_t &options) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xclaim(key, group, consumer, min_idle_time, id_members, options, cb);
-		});
-	}
-
-	std::future<reply> client::xdel(const std::string &key, const std::vector<std::string> &id_members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xdel(key, id_members, cb);
-		});
-	}
-
-	std::future<reply>
-	client::xgroup_create(const std::string &key, const std::string &group_name, const std::string &id) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xgroup_create(key, group_name, id, cb);
-		});
-	}
-
-	std::future<reply>
-	client::xgroup_set_id(const std::string &key, const std::string &group_name, const std::string &id) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xgroup_set_id(key, group_name, id, cb);
-		});
-	}
-
-	std::future<reply> client::xgroup_destroy(const std::string &key, const std::string &group_name) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xgroup_destroy(key, group_name, cb);
-		});
-	}
-
-	std::future<reply>
-	client::xgroup_del_consumer(const std::string &key, const std::string &group_name, const std::string &consumer_name) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xgroup_del_consumer(key, group_name, consumer_name, cb);
-		});
-	}
-
-	/** @htmlinclude https://redis.io/commands/xdel
+std::future<reply>
+client::exec_cmd(const std::function<client&(const reply_callback_t&)>& f) {
+  auto prms = std::make_shared<std::promise<reply>>();
+
+  f([prms](reply& reply) {
+    prms->set_value(reply);
+  });
+
+  return prms->get_future();
+}
+
+std::future<reply>
+client::send(const std::vector<std::string>& redis_cmd) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return send(redis_cmd, cb); });
+}
+
+std::future<reply>
+client::append(const std::string& key, const std::string& value) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return append(key, value, cb); });
+}
+
+std::future<reply>
+client::auth(const std::string& password) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return auth(password, cb); });
+}
+
+std::future<reply>
+client::bgrewriteaof() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return bgrewriteaof(cb); });
+}
+
+std::future<reply>
+client::bgsave() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return bgsave(cb); });
+}
+
+std::future<reply>
+client::bitcount(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return bitcount(key, cb); });
+}
+
+std::future<reply>
+client::bitcount(const std::string& key, int start, int end) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return bitcount(key, start, end, cb); });
+}
+
+std::future<reply>
+client::bitfield(const std::string& key, const std::vector<bitfield_operation>& operations) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return bitfield(key, operations, cb); });
+}
+
+std::future<reply>
+client::bitop(const std::string& operation, const std::string& destkey, const std::vector<std::string>& keys) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return bitop(operation, destkey, keys, cb); });
+}
+
+std::future<reply>
+client::bitpos(const std::string& key, int bit) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return bitpos(key, bit, cb); });
+}
+
+std::future<reply>
+client::bitpos(const std::string& key, int bit, int start) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return bitpos(key, bit, start, cb); });
+}
+
+std::future<reply>
+client::bitpos(const std::string& key, int bit, int start, int end) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return bitpos(key, bit, start, end, cb); });
+}
+
+std::future<reply>
+client::blpop(const std::vector<std::string>& keys, int timeout) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return blpop(keys, timeout, cb); });
+}
+
+std::future<reply>
+client::brpop(const std::vector<std::string>& keys, int timeout) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return brpop(keys, timeout, cb); });
+}
+
+std::future<reply>
+client::brpoplpush(const std::string& src, const std::string& dst, int timeout) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return brpoplpush(src, dst, timeout, cb); });
+}
+
+std::future<reply>
+client::bzpopmin(const std::vector<std::string>& keys, int timeout) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return bzpopmin(keys, timeout, cb); });
+}
+
+std::future<reply>
+client::bzpopmax(const std::vector<std::string>& keys, int timeout) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return bzpopmax(keys, timeout, cb); });
+}
+
+std::future<reply>
+client::client_id() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return client_id(cb); });
+}
+
+std::future<reply>
+client::client_list() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return client_list(cb); });
+}
+
+std::future<reply>
+client::client_getname() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return client_getname(cb); });
+}
+
+std::future<reply>
+client::client_pause(int timeout) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return client_pause(timeout, cb); });
+}
+
+std::future<reply>
+client::client_reply(const std::string& mode) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return client_reply(mode, cb); });
+}
+
+std::future<reply>
+client::client_setname(const std::string& name) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return client_setname(name, cb); });
+}
+
+std::future<reply>
+client::client_unblock(int id, bool witherror) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return client_unblock(id, witherror, cb); });
+}
+
+std::future<reply>
+client::cluster_addslots(const std::vector<std::string>& p_slots) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_addslots(p_slots, cb); });
+}
+
+std::future<reply>
+client::cluster_count_failure_reports(const std::string& node_id) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_count_failure_reports(node_id, cb); });
+}
+
+std::future<reply>
+client::cluster_countkeysinslot(const std::string& slot) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_countkeysinslot(slot, cb); });
+}
+
+std::future<reply>
+client::cluster_delslots(const std::vector<std::string>& p_slots) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_delslots(p_slots, cb); });
+}
+
+std::future<reply>
+client::cluster_failover() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_failover(cb); });
+}
+
+std::future<reply>
+client::cluster_failover(const std::string& mode) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_failover(mode, cb); });
+}
+
+std::future<reply>
+client::cluster_forget(const std::string& node_id) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_forget(node_id, cb); });
+}
+
+std::future<reply>
+client::cluster_getkeysinslot(const std::string& slot, int count) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_getkeysinslot(slot, count, cb); });
+}
+
+std::future<reply>
+client::cluster_info() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_info(cb); });
+}
+
+std::future<reply>
+client::cluster_keyslot(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_keyslot(key, cb); });
+}
+
+std::future<reply>
+client::cluster_meet(const std::string& ip, int port) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_meet(ip, port, cb); });
+}
+
+std::future<reply>
+client::cluster_nodes() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_nodes(cb); });
+}
+
+std::future<reply>
+client::cluster_replicate(const std::string& node_id) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_replicate(node_id, cb); });
+}
+
+std::future<reply>
+client::cluster_reset(const std::string& mode) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_reset(mode, cb); });
+}
+
+std::future<reply>
+client::cluster_saveconfig() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_saveconfig(cb); });
+}
+
+std::future<reply>
+client::cluster_set_config_epoch(const std::string& epoch) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_set_config_epoch(epoch, cb); });
+}
+
+std::future<reply>
+client::cluster_setslot(const std::string& slot, const std::string& mode) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_setslot(slot, mode, cb); });
+}
+
+std::future<reply>
+client::cluster_setslot(const std::string& slot, const std::string& mode, const std::string& node_id) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_setslot(slot, mode, node_id, cb); });
+}
+
+std::future<reply>
+client::cluster_slaves(const std::string& node_id) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_slaves(node_id, cb); });
+}
+
+std::future<reply>
+client::cluster_slots() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return cluster_slots(cb); });
+}
+
+std::future<reply>
+client::command() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return command(cb); });
+}
+
+std::future<reply>
+client::command_count() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return command_count(cb); });
+}
+
+std::future<reply>
+client::command_getkeys() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return command_getkeys(cb); });
+}
+
+std::future<reply>
+client::command_info(const std::vector<std::string>& command_name) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return command_info(command_name, cb); });
+}
+
+std::future<reply>
+client::config_get(const std::string& param) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return config_get(param, cb); });
+}
+
+std::future<reply>
+client::config_rewrite() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return config_rewrite(cb); });
+}
+
+std::future<reply>
+client::config_set(const std::string& param, const std::string& val) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return config_set(param, val, cb); });
+}
+
+std::future<reply>
+client::config_resetstat() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return config_resetstat(cb); });
+}
+
+std::future<reply>
+client::dbsize() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return dbsize(cb); });
+}
+
+std::future<reply>
+client::debug_object(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return debug_object(key, cb); });
+}
+
+std::future<reply>
+client::debug_segfault() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return debug_segfault(cb); });
+}
+
+std::future<reply>
+client::decr(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return decr(key, cb); });
+}
+
+std::future<reply>
+client::decrby(const std::string& key, int val) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return decrby(key, val, cb); });
+}
+
+std::future<reply>
+client::del(const std::vector<std::string>& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return del(key, cb); });
+}
+
+std::future<reply>
+client::discard() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return discard(cb); });
+}
+
+std::future<reply>
+client::dump(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return dump(key, cb); });
+}
+
+std::future<reply>
+client::echo(const std::string& msg) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return echo(msg, cb); });
+}
+
+std::future<reply>
+client::eval(const std::string& script, int numkeys, const std::vector<std::string>& keys,
+  const std::vector<std::string>& args) {
+  (void) numkeys;
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return eval(script, keys, args, cb); });
+}
+
+std::future<reply>
+client::eval(const std::string& script, const std::vector<std::string>& keys,
+  const std::vector<std::string>& args) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return eval(script, keys, args, cb); });
+}
+
+std::future<reply>
+client::evalsha(const std::string& sha1, const std::vector<std::string>& keys,
+  const std::vector<std::string>& args) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return evalsha(sha1, keys, args, cb); });
+}
+
+std::future<reply>
+client::evalsha(const std::string& sha1, int numkeys, const std::vector<std::string>& keys,
+  const std::vector<std::string>& args) {
+  (void) numkeys;
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return evalsha(sha1, keys, args, cb); });
+}
+
+std::future<reply>
+client::exec() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return exec(cb); });
+}
+
+std::future<reply>
+client::exists(const std::vector<std::string>& keys) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return exists(keys, cb); });
+}
+
+std::future<reply>
+client::expire(const std::string& key, int seconds) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return expire(key, seconds, cb); });
+}
+
+std::future<reply>
+client::expireat(const std::string& key, int timestamp) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return expireat(key, timestamp, cb); });
+}
+
+std::future<reply>
+client::flushall() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return flushall(cb); });
+}
+
+std::future<reply>
+client::flushdb() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return flushdb(cb); });
+}
+
+std::future<reply>
+client::geoadd(const std::string& key,
+  const std::vector<std::tuple<std::string, std::string, std::string>>& long_lat_memb) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return geoadd(key, long_lat_memb, cb); });
+}
+
+std::future<reply>
+client::geohash(const std::string& key, const std::vector<std::string>& members) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return geohash(key, members, cb); });
+}
+
+std::future<reply>
+client::geopos(const std::string& key, const std::vector<std::string>& members) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return geopos(key, members, cb); });
+}
+
+std::future<reply>
+client::geodist(const std::string& key, const std::string& member_1, const std::string& member_2,
+  const std::string& unit) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return geodist(key, member_1, member_2, unit, cb); });
+}
+
+std::future<reply>
+client::georadius(const std::string& key, double longitude, double latitude, double radius, geo_unit unit,
+  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
+  const std::string& store_key, const std::string& storedist_key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return georadius(key, longitude, latitude, radius, unit, with_coord, with_dist, with_hash, asc_order, count,
+      store_key, storedist_key, cb);
+  });
+}
+
+std::future<reply>
+client::georadiusbymember(const std::string& key, const std::string& member, double radius, geo_unit unit,
+  bool with_coord, bool with_dist, bool with_hash, bool asc_order, std::size_t count,
+  const std::string& store_key, const std::string& storedist_key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return georadiusbymember(key, member, radius, unit, with_coord, with_dist, with_hash, asc_order, count,
+      store_key, storedist_key, cb);
+  });
+}
+
+std::future<reply>
+client::get(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return get(key, cb); });
+}
+
+std::future<reply>
+client::getbit(const std::string& key, int offset) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return getbit(key, offset, cb); });
+}
+
+std::future<reply>
+client::getrange(const std::string& key, int start, int end) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return getrange(key, start, end, cb); });
+}
+
+std::future<reply>
+client::getset(const std::string& key, const std::string& val) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return getset(key, val, cb); });
+}
+
+std::future<reply>
+client::hdel(const std::string& key, const std::vector<std::string>& fields) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hdel(key, fields, cb); });
+}
+
+std::future<reply>
+client::hexists(const std::string& key, const std::string& field) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hexists(key, field, cb); });
+}
+
+std::future<reply>
+client::hget(const std::string& key, const std::string& field) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hget(key, field, cb); });
+}
+
+std::future<reply>
+client::hgetall(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hgetall(key, cb); });
+}
+
+std::future<reply>
+client::hincrby(const std::string& key, const std::string& field, int incr) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hincrby(key, field, incr, cb); });
+}
+
+std::future<reply>
+client::hincrbyfloat(const std::string& key, const std::string& field, float incr) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hincrbyfloat(key, field, incr, cb); });
+}
+
+std::future<reply>
+client::hkeys(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hkeys(key, cb); });
+}
+
+std::future<reply>
+client::hlen(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hlen(key, cb); });
+}
+
+std::future<reply>
+client::hmget(const std::string& key, const std::vector<std::string>& fields) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hmget(key, fields, cb); });
+}
+
+std::future<reply>
+client::hmset(const std::string& key, const std::vector<std::pair<std::string, std::string>>& field_val) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hmset(key, field_val, cb); });
+}
+
+std::future<reply>
+client::hscan(const std::string& key, std::size_t cursor) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hscan(key, cursor, cb); });
+}
+
+std::future<reply>
+client::hscan(const std::string& key, std::size_t cursor, const std::string& pattern) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hscan(key, cursor, pattern, cb); });
+}
+
+std::future<reply>
+client::hscan(const std::string& key, std::size_t cursor, std::size_t count) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hscan(key, cursor, count, cb); });
+}
+
+std::future<reply>
+client::hscan(const std::string& key, std::size_t cursor, const std::string& pattern, std::size_t count) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hscan(key, cursor, pattern, count, cb); });
+}
+
+std::future<reply>
+client::hset(const std::string& key, const std::string& field, const std::string& value) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hset(key, field, value, cb); });
+}
+
+std::future<reply>
+client::hsetnx(const std::string& key, const std::string& field, const std::string& value) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hsetnx(key, field, value, cb); });
+}
+
+std::future<reply>
+client::hstrlen(const std::string& key, const std::string& field) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hstrlen(key, field, cb); });
+}
+
+std::future<reply>
+client::hvals(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return hvals(key, cb); });
+}
+
+std::future<reply>
+client::incr(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return incr(key, cb); });
+}
+
+std::future<reply>
+client::incrby(const std::string& key, int incr) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return incrby(key, incr, cb); });
+}
+
+std::future<reply>
+client::incrbyfloat(const std::string& key, float incr) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return incrbyfloat(key, incr, cb); });
+}
+
+std::future<reply>
+client::info(const std::string& section) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return info(section, cb); });
+}
+
+std::future<reply>
+client::keys(const std::string& pattern) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return keys(pattern, cb); });
+}
+
+std::future<reply>
+client::lastsave() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return lastsave(cb); });
+}
+
+std::future<reply>
+client::lindex(const std::string& key, int index) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return lindex(key, index, cb); });
+}
+
+std::future<reply>
+client::linsert(const std::string& key, const std::string& before_after, const std::string& pivot,
+  const std::string& value) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return linsert(key, before_after, pivot, value, cb); });
+}
+
+std::future<reply>
+client::llen(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return llen(key, cb); });
+}
+
+std::future<reply>
+client::lpop(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return lpop(key, cb); });
+}
+
+std::future<reply>
+client::lpush(const std::string& key, const std::vector<std::string>& values) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return lpush(key, values, cb); });
+}
+
+std::future<reply>
+client::lpushx(const std::string& key, const std::string& value) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return lpushx(key, value, cb); });
+}
+
+std::future<reply>
+client::lrange(const std::string& key, int start, int stop) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return lrange(key, start, stop, cb); });
+}
+
+std::future<reply>
+client::lrem(const std::string& key, int count, const std::string& value) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return lrem(key, count, value, cb); });
+}
+
+std::future<reply>
+client::lset(const std::string& key, int index, const std::string& value) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return lset(key, index, value, cb); });
+}
+
+std::future<reply>
+client::ltrim(const std::string& key, int start, int stop) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return ltrim(key, start, stop, cb); });
+}
+
+std::future<reply>
+client::mget(const std::vector<std::string>& keys) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return mget(keys, cb); });
+}
+
+std::future<reply>
+client::migrate(const std::string& host, int port, const std::string& key, const std::string& dest_db, int timeout,
+  bool copy, bool replace, const std::vector<std::string>& keys) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return migrate(host, port, key, dest_db, timeout, copy, replace, keys, cb);
+  });
+}
+
+std::future<reply>
+client::monitor() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return monitor(cb); });
+}
+
+std::future<reply>
+client::move(const std::string& key, const std::string& db) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return move(key, db, cb); });
+}
+
+std::future<reply>
+client::mset(const std::vector<std::pair<std::string, std::string>>& key_vals) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return mset(key_vals, cb); });
+}
+
+std::future<reply>
+client::msetnx(const std::vector<std::pair<std::string, std::string>>& key_vals) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return msetnx(key_vals, cb); });
+}
+
+std::future<reply>
+client::multi() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return multi(cb); });
+}
+
+std::future<reply>
+client::object(const std::string& subcommand, const std::vector<std::string>& args) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return object(subcommand, args, cb); });
+}
+
+std::future<reply>
+client::persist(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return persist(key, cb); });
+}
+
+std::future<reply>
+client::pexpire(const std::string& key, int ms) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return pexpire(key, ms, cb); });
+}
+
+std::future<reply>
+client::pexpireat(const std::string& key, int ms_timestamp) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return pexpireat(key, ms_timestamp, cb); });
+}
+
+std::future<reply>
+client::pfadd(const std::string& key, const std::vector<std::string>& elements) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return pfadd(key, elements, cb); });
+}
+
+std::future<reply>
+client::pfcount(const std::vector<std::string>& keys) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return pfcount(keys, cb); });
+}
+
+std::future<reply>
+client::pfmerge(const std::string& destkey, const std::vector<std::string>& sourcekeys) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return pfmerge(destkey, sourcekeys, cb); });
+}
+
+std::future<reply>
+client::ping() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return ping(cb); });
+}
+
+std::future<reply>
+client::ping(const std::string& message) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return ping(message, cb); });
+}
+
+std::future<reply>
+client::psetex(const std::string& key, int64_t ms, const std::string& val) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return psetex(key, ms, val, cb); });
+}
+
+std::future<reply>
+client::publish(const std::string& channel, const std::string& message) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return publish(channel, message, cb); });
+}
+
+std::future<reply>
+client::pubsub(const std::string& subcommand, const std::vector<std::string>& args) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return pubsub(subcommand, args, cb); });
+}
+
+std::future<reply>
+client::pttl(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return pttl(key, cb); });
+}
+
+std::future<reply>
+client::quit() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return quit(cb); });
+}
+
+std::future<reply>
+client::randomkey() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return randomkey(cb); });
+}
+
+std::future<reply>
+client::readonly() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return readonly(cb); });
+}
+
+std::future<reply>
+client::readwrite() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return readwrite(cb); });
+}
+
+std::future<reply>
+client::rename(const std::string& key, const std::string& newkey) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return rename(key, newkey, cb); });
+}
+
+std::future<reply>
+client::renamenx(const std::string& key, const std::string& newkey) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return renamenx(key, newkey, cb); });
+}
+
+std::future<reply>
+client::restore(const std::string& key, int ttl, const std::string& serialized_value) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return restore(key, ttl, serialized_value, cb); });
+}
+
+std::future<reply>
+client::restore(const std::string& key, int ttl, const std::string& serialized_value, const std::string& replace) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return restore(key, ttl, serialized_value, replace, cb); });
+}
+
+std::future<reply>
+client::role() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return role(cb); });
+}
+
+std::future<reply>
+client::rpop(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return rpop(key, cb); });
+}
+
+std::future<reply>
+client::rpoplpush(const std::string& src, const std::string& dst) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return rpoplpush(src, dst, cb); });
+}
+
+std::future<reply>
+client::rpush(const std::string& key, const std::vector<std::string>& values) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return rpush(key, values, cb); });
+}
+
+std::future<reply>
+client::rpushx(const std::string& key, const std::string& value) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return rpushx(key, value, cb); });
+}
+
+std::future<reply>
+client::sadd(const std::string& key, const std::vector<std::string>& members) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return sadd(key, members, cb); });
+}
+
+std::future<reply>
+client::scan(std::size_t cursor) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return scan(cursor, cb); });
+}
+
+std::future<reply>
+client::scan(std::size_t cursor, const std::string& pattern) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return scan(cursor, pattern, cb); });
+}
+
+std::future<reply>
+client::scan(std::size_t cursor, std::size_t count) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return scan(cursor, count, cb); });
+}
+
+std::future<reply>
+client::scan(std::size_t cursor, const std::string& pattern, std::size_t count) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return scan(cursor, pattern, count, cb); });
+}
+
+std::future<reply>
+client::save() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return save(cb); });
+}
+
+std::future<reply>
+client::scard(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return scard(key, cb); });
+}
+
+std::future<reply>
+client::script_debug(const std::string& mode) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return script_debug(mode, cb); });
+}
+
+std::future<reply>
+client::script_exists(const std::vector<std::string>& scripts) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return script_exists(scripts, cb); });
+}
+
+std::future<reply>
+client::script_flush() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return script_flush(cb); });
+}
+
+std::future<reply>
+client::script_kill() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return script_kill(cb); });
+}
+
+std::future<reply>
+client::script_load(const std::string& script) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return script_load(script, cb); });
+}
+
+std::future<reply>
+client::sdiff(const std::vector<std::string>& keys) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return sdiff(keys, cb); });
+}
+
+std::future<reply>
+client::sdiffstore(const std::string& dst, const std::vector<std::string>& keys) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return sdiffstore(dst, keys, cb); });
+}
+
+std::future<reply>
+client::select(int index) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return select(index, cb); });
+}
+
+std::future<reply>
+client::set(const std::string& key, const std::string& value) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return set(key, value, cb); });
+}
+
+std::future<reply>
+client::set_advanced(const std::string& key, const std::string& value, bool ex, int ex_sec, bool px, int px_milli,
+  bool nx, bool xx) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return set_advanced(key, value, ex, ex_sec, px, px_milli, nx, xx, cb);
+  });
+}
+
+std::future<reply>
+client::setbit_(const std::string& key, int offset, const std::string& value) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return setbit_(key, offset, value, cb); });
+}
+
+std::future<reply>
+client::setex(const std::string& key, int64_t seconds, const std::string& value) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return setex(key, seconds, value, cb); });
+}
+
+std::future<reply>
+client::setnx(const std::string& key, const std::string& value) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return setnx(key, value, cb); });
+}
+
+std::future<reply>
+client::setrange(const std::string& key, int offset, const std::string& value) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return setrange(key, offset, value, cb); });
+}
+
+std::future<reply>
+client::shutdown() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return shutdown(cb); });
+}
+
+std::future<reply>
+client::shutdown(const std::string& save) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return shutdown(save, cb); });
+}
+
+std::future<reply>
+client::sinter(const std::vector<std::string>& keys) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return sinter(keys, cb); });
+}
+
+std::future<reply>
+client::sinterstore(const std::string& dst, const std::vector<std::string>& keys) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return sinterstore(dst, keys, cb); });
+}
+
+std::future<reply>
+client::sismember(const std::string& key, const std::string& member) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return sismember(key, member, cb); });
+}
+
+std::future<reply>
+client::slaveof(const std::string& host, int port) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return slaveof(host, port, cb); });
+}
+
+std::future<reply>
+client::slowlog(const std::string& subcommand) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return slowlog(subcommand, cb); });
+}
+
+std::future<reply>
+client::slowlog(const std::string& subcommand, const std::string& argument) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return slowlog(subcommand, argument, cb); });
+}
+
+std::future<reply>
+client::smembers(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return smembers(key, cb); });
+}
+
+std::future<reply>
+client::smove(const std::string& src, const std::string& dst, const std::string& member) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return smove(src, dst, member, cb); });
+}
+
+std::future<reply>
+client::sort(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return sort(key, cb); });
+}
+
+std::future<reply>
+client::sort(const std::string& key, const std::vector<std::string>& get_patterns, bool asc_order, bool alpha) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return sort(key, get_patterns, asc_order, alpha, cb); });
+}
+
+std::future<reply>
+client::sort(const std::string& key, std::size_t offset, std::size_t count,
+  const std::vector<std::string>& get_patterns, bool asc_order, bool alpha) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return sort(key, offset, count, get_patterns, asc_order, alpha, cb);
+  });
+}
+
+std::future<reply>
+client::sort(const std::string& key, const std::string& by_pattern, const std::vector<std::string>& get_patterns,
+  bool asc_order, bool alpha) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return sort(key, by_pattern, get_patterns, asc_order, alpha, cb);
+  });
+}
+
+std::future<reply>
+client::sort(const std::string& key, const std::vector<std::string>& get_patterns, bool asc_order, bool alpha,
+  const std::string& store_dest) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return sort(key, get_patterns, asc_order, alpha, store_dest, cb);
+  });
+}
+
+std::future<reply>
+client::sort(const std::string& key, std::size_t offset, std::size_t count,
+  const std::vector<std::string>& get_patterns, bool asc_order, bool alpha,
+  const std::string& store_dest) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return sort(key, offset, count, get_patterns, asc_order, alpha, store_dest, cb);
+  });
+}
+
+std::future<reply>
+client::sort(const std::string& key, const std::string& by_pattern, const std::vector<std::string>& get_patterns,
+  bool asc_order, bool alpha, const std::string& store_dest) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return sort(key, by_pattern, get_patterns, asc_order, alpha, store_dest, cb);
+  });
+}
+
+std::future<reply>
+client::sort(const std::string& key, const std::string& by_pattern, std::size_t offset, std::size_t count,
+  const std::vector<std::string>& get_patterns, bool asc_order, bool alpha) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return sort(key, by_pattern, offset, count, get_patterns, asc_order, alpha, cb);
+  });
+}
+
+std::future<reply>
+client::sort(const std::string& key, const std::string& by_pattern, std::size_t offset, std::size_t count,
+  const std::vector<std::string>& get_patterns, bool asc_order, bool alpha,
+  const std::string& store_dest) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return sort(key, by_pattern, offset, count, get_patterns, asc_order, alpha, store_dest, cb);
+  });
+}
+
+std::future<reply>
+client::spop(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return spop(key, cb); });
+}
+
+std::future<reply>
+client::spop(const std::string& key, int count) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return spop(key, count, cb); });
+}
+
+std::future<reply>
+client::srandmember(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return srandmember(key, cb); });
+}
+
+std::future<reply>
+client::srandmember(const std::string& key, int count) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return srandmember(key, count, cb); });
+}
+
+std::future<reply>
+client::srem(const std::string& key, const std::vector<std::string>& members) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return srem(key, members, cb); });
+}
+
+std::future<reply>
+client::sscan(const std::string& key, std::size_t cursor) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return sscan(key, cursor, cb); });
+}
+
+std::future<reply>
+client::sscan(const std::string& key, std::size_t cursor, const std::string& pattern) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return sscan(key, cursor, pattern, cb); });
+}
+
+std::future<reply>
+client::sscan(const std::string& key, std::size_t cursor, std::size_t count) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return sscan(key, cursor, count, cb); });
+}
+
+std::future<reply>
+client::sscan(const std::string& key, std::size_t cursor, const std::string& pattern, std::size_t count) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return sscan(key, cursor, pattern, count, cb); });
+}
+
+std::future<reply>
+client::strlen(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return strlen(key, cb); });
+}
+
+std::future<reply>
+client::sunion(const std::vector<std::string>& keys) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return sunion(keys, cb); });
+}
+
+std::future<reply>
+client::sunionstore(const std::string& dst, const std::vector<std::string>& keys) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return sunionstore(dst, keys, cb); });
+}
+
+std::future<reply>
+client::sync() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return sync(cb); });
+}
+
+std::future<reply>
+client::time() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return time(cb); });
+}
+
+std::future<reply>
+client::ttl(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return ttl(key, cb); });
+}
+
+std::future<reply>
+client::type(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return type(key, cb); });
+}
+
+std::future<reply>
+client::unwatch() {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return unwatch(cb); });
+}
+
+std::future<reply>
+client::wait(int numslaves, int timeout) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return wait(numslaves, timeout, cb); });
+}
+
+std::future<reply>
+client::watch(const std::vector<std::string>& keys) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return watch(keys, cb); });
+}
+
+std::future<reply>
+client::xack(const std::string& key, const std::string& group, const std::vector<std::string>& id_members) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return xack(key, group, id_members, cb); });
+}
+
+std::future<reply>
+client::xadd(const std::string& key, const std::string& id,
+  const std::multimap<std::string, std::string>& field_members) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xadd(key, id, field_members, cb);
+  });
+}
+
+std::future<reply>
+client::xclaim(const std::string& key, const std::string& group, const std::string& consumer,
+  const int& min_idle_time, const std::vector<std::string>& id_members, const xclaim_options_t& options) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xclaim(key, group, consumer, min_idle_time, id_members, options, cb);
+  });
+}
+
+std::future<reply>
+client::xdel(const std::string& key, const std::vector<std::string>& id_members) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xdel(key, id_members, cb);
+  });
+}
+
+std::future<reply>
+client::xgroup_create(const std::string& key, const std::string& group_name, const std::string& id) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xgroup_create(key, group_name, id, cb);
+  });
+}
+
+std::future<reply>
+client::xgroup_set_id(const std::string& key, const std::string& group_name, const std::string& id) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xgroup_set_id(key, group_name, id, cb);
+  });
+}
+
+std::future<reply>
+client::xgroup_destroy(const std::string& key, const std::string& group_name) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xgroup_destroy(key, group_name, cb);
+  });
+}
+
+std::future<reply>
+client::xgroup_del_consumer(const std::string& key, const std::string& group_name, const std::string& consumer_name) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xgroup_del_consumer(key, group_name, consumer_name, cb);
+  });
+}
+
+/** @htmlinclude https://redis.io/commands/xdel
 	 * @brief introspection command used in order to retrieve different information about the consumer groups
 	 * @param key
 	 * @param group_name stream consumer group name
 	 * @return
 	 */
-	std::future<reply> client::xinfo_consumers(const std::string &key, const std::string &group_name) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xinfo_consumers(key, group_name, cb);
-		});
-	}
-
-	std::future<reply> client::xinfo_groups(const std::string &stream) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xinfo_groups(stream, cb);
-		});
-	}
-
-	std::future<reply> client::xinfo_stream(const std::string &stream) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xinfo_stream(stream, cb);
-		});
-	}
-
-	std::future<reply> client::xlen(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xlen(key, cb);
-		});
-	}
-
-	std::future<reply> client::xpending(const std::string &stream,
-	                            const std::string &group,
-	                            const xpending_options_t &options) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xpending(stream, group, options, cb);
-		});
-	}
-
-	std::future<reply> client::xrange(const std::string &stream, const range_options_t &range_args) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xrange(stream, range_args, cb);
-		});
-	}
-
-	std::future<reply> client::xreadgroup(const xreadgroup_options_t &a) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xreadgroup(a, cb);
-		});
-	}
-
-	std::future<reply> client::xread(const xread_options_t &a) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xread(a, cb);
-		});
-	}
-
-	std::future<reply> client::xrevrange(const std::string &key, const range_options_t &range_args) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xrevrange(key, range_args, cb);
-		});
-	}
-
-	std::future<reply> client::xtrim(const std::string &key, int max_len) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xtrim(key, max_len, cb);
-		});
-	}
-	std::future<reply> client::xtrim_approx(const std::string &key, int max_len) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return xtrim_approx(key, max_len, cb);
-		});
-	}
-
-	std::future<reply>
-	client::zadd(const std::string &key, const std::vector<std::string> &options,
-	             const std::multimap<std::string, std::string> &score_members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zadd(key, options, score_members, cb); });
-	}
-
-	std::future<reply>
-	client::zcard(const std::string &key) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zcard(key, cb); });
-	}
-
-	std::future<reply>
-	client::zcount(const std::string &key, int min, int max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zcount(key, min, max, cb); });
-	}
-
-	std::future<reply>
-	client::zcount(const std::string &key, double min, double max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zcount(key, min, max, cb); });
-	}
-
-	std::future<reply>
-	client::zcount(const std::string &key, const std::string &min, const std::string &max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zcount(key, min, max, cb); });
-	}
-
-	std::future<reply>
-	client::zincrby(const std::string &key, int incr, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zincrby(key, incr, member, cb); });
-	}
-
-	std::future<reply>
-	client::zincrby(const std::string &key, double incr, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zincrby(key, incr, member, cb); });
-	}
-
-	std::future<reply>
-	client::zincrby(const std::string &key, const std::string &incr, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zincrby(key, incr, member, cb); });
-	}
-
-	std::future<reply>
-	client::zinterstore(const std::string &destination, std::size_t numkeys, const std::vector<std::string> &keys,
-	                    const std::vector<std::size_t> weights, aggregate_method method) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return zinterstore(destination, numkeys, keys, weights, method, cb);
-		});
-	}
-
-	std::future<reply>
-	client::zlexcount(const std::string &key, int min, int max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zlexcount(key, min, max, cb); });
-	}
-
-	std::future<reply>
-	client::zlexcount(const std::string &key, double min, double max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zlexcount(key, min, max, cb); });
-	}
-
-	std::future<reply>
-	client::zlexcount(const std::string &key, const std::string &min, const std::string &max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zlexcount(key, min, max, cb); });
-	}
-
-	std::future<reply>
-	client::zpopmin(const std::string& key, int count) {
-		return exec_cmd([=](const reply_callback_t& cb) -> client& { return zpopmin(key, count, cb); });
-	}
-	std::future<reply>
-	client::zpopmax(const std::string& key, int count) {
-		return exec_cmd([=](const reply_callback_t& cb) -> client& { return zpopmax(key, count, cb); });
-	}
-
-	std::future<reply>
-	client::zrange(const std::string &key, int start, int stop, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrange(key, start, stop, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrange(const std::string &key, double start, double stop, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrange(key, start, stop, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrange(const std::string &key, const std::string &start, const std::string &stop, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrange(key, start, stop, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrangebylex(const std::string &key, int min, int max, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrangebylex(key, min, max, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrangebylex(const std::string &key, double min, double max, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrangebylex(key, min, max, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrangebylex(const std::string &key, const std::string &min, const std::string &max, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrangebylex(key, min, max, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrangebylex(const std::string &key, int min, int max, std::size_t offset, std::size_t count,
-	                    bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return zrangebylex(key, min, max, offset, count, withscores, cb);
-		});
-	}
-
-	std::future<reply>
-	client::zrangebylex(const std::string &key, double min, double max, std::size_t offset, std::size_t count,
-	                    bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return zrangebylex(key, min, max, offset, count, withscores, cb);
-		});
-	}
-
-	std::future<reply>
-	client::zrangebylex(const std::string &key, const std::string &min, const std::string &max, std::size_t offset,
-	                    std::size_t count, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return zrangebylex(key, min, max, offset, count, withscores, cb);
-		});
-	}
-
-	std::future<reply>
-	client::zrangebyscore(const std::string &key, int min, int max, bool withscores) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrangebyscore(key, min, max, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrangebyscore(const std::string &key, double min, double max, bool withscores) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrangebyscore(key, min, max, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrangebyscore(const std::string &key, const std::string &min, const std::string &max, bool withscores) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrangebyscore(key, min, max, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrangebyscore(const std::string &key, int min, int max, std::size_t offset, std::size_t count,
-	                      bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return zrangebyscore(key, min, max, offset, count, withscores, cb);
-		});
-	}
-
-	std::future<reply>
-	client::zrangebyscore(const std::string &key, double min, double max, std::size_t offset, std::size_t count,
-	                      bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return zrangebyscore(key, min, max, offset, count, withscores, cb);
-		});
-	}
-
-	std::future<reply>
-	client::zrangebyscore(const std::string &key, const std::string &min, const std::string &max, std::size_t offset,
-	                      std::size_t count, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return zrangebyscore(key, min, max, offset, count, withscores, cb);
-		});
-	}
-
-	std::future<reply>
-	client::zrank(const std::string &key, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrank(key, member, cb); });
-	}
-
-	std::future<reply>
-	client::zrem(const std::string &key, const std::vector<std::string> &members) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrem(key, members, cb); });
-	}
-
-	std::future<reply>
-	client::zremrangebylex(const std::string &key, int min, int max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebylex(key, min, max, cb); });
-	}
-
-	std::future<reply>
-	client::zremrangebylex(const std::string &key, double min, double max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebylex(key, min, max, cb); });
-	}
-
-	std::future<reply>
-	client::zremrangebylex(const std::string &key, const std::string &min, const std::string &max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebylex(key, min, max, cb); });
-	}
-
-	std::future<reply>
-	client::zremrangebyrank(const std::string &key, int start, int stop) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebyrank(key, start, stop, cb); });
-	}
-
-	std::future<reply>
-	client::zremrangebyrank(const std::string &key, double start, double stop) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebyrank(key, start, stop, cb); });
-	}
-
-	std::future<reply>
-	client::zremrangebyrank(const std::string &key, const std::string &start, const std::string &stop) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebyrank(key, start, stop, cb); });
-	}
-
-	std::future<reply>
-	client::zremrangebyscore(const std::string &key, int min, int max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebyscore(key, min, max, cb); });
-	}
-
-	std::future<reply>
-	client::zremrangebyscore(const std::string &key, double min, double max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebyscore(key, min, max, cb); });
-	}
-
-	std::future<reply>
-	client::zremrangebyscore(const std::string &key, const std::string &min, const std::string &max) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zremrangebyscore(key, min, max, cb); });
-	}
-
-	std::future<reply>
-	client::zrevrange(const std::string &key, int start, int stop, bool withscores) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrange(key, start, stop, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrevrange(const std::string &key, double start, double stop, bool withscores) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrange(key, start, stop, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrevrange(const std::string &key, const std::string &start, const std::string &stop, bool withscores) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrange(key, start, stop, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrevrangebylex(const std::string &key, int max, int min, bool withscores) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrangebylex(key, max, min, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrevrangebylex(const std::string &key, double max, double min, bool withscores) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrangebylex(key, max, min, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrevrangebylex(const std::string &key, const std::string &max, const std::string &min, bool withscores) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrangebylex(key, max, min, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrevrangebylex(const std::string &key, int max, int min, std::size_t offset, std::size_t count,
-	                       bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return zrevrangebylex(key, max, min, offset, count, withscores, cb);
-		});
-	}
-
-	std::future<reply>
-	client::zrevrangebylex(const std::string &key, double max, double min, std::size_t offset, std::size_t count,
-	                       bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return zrevrangebylex(key, max, min, offset, count, withscores, cb);
-		});
-	}
-
-	std::future<reply>
-	client::zrevrangebylex(const std::string &key, const std::string &max, const std::string &min, std::size_t offset,
-	                       std::size_t count, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return zrevrangebylex(key, max, min, offset, count, withscores, cb);
-		});
-	}
-
-	std::future<reply>
-	client::zrevrangebyscore(const std::string &key, int max, int min, bool withscores) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrangebyscore(key, max, min, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrevrangebyscore(const std::string &key, double max, double min, bool withscores) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrangebyscore(key, max, min, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min, bool withscores) {
-		return exec_cmd(
-				[=](const reply_callback_t &cb) -> client & { return zrevrangebyscore(key, max, min, withscores, cb); });
-	}
-
-	std::future<reply>
-	client::zrevrangebyscore(const std::string &key, int max, int min, std::size_t offset, std::size_t count,
-	                         bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return zrevrangebyscore(key, max, min, offset, count, withscores, cb);
-		});
-	}
-
-	std::future<reply>
-	client::zrevrangebyscore(const std::string &key, double max, double min, std::size_t offset, std::size_t count,
-	                         bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return zrevrangebyscore(key, max, min, offset, count, withscores, cb);
-		});
-	}
-
-	std::future<reply>
-	client::zrevrangebyscore(const std::string &key, const std::string &max, const std::string &min, std::size_t offset,
-	                         std::size_t count, bool withscores) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return zrevrangebyscore(key, max, min, offset, count, withscores, cb);
-		});
-	}
-
-	std::future<reply>
-	client::zrevrank(const std::string &key, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zrevrank(key, member, cb); });
-	}
-
-	std::future<reply>
-	client::zscan(const std::string &key, std::size_t cursor) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zscan(key, cursor, cb); });
-	}
-
-	std::future<reply>
-	client::zscan(const std::string &key, std::size_t cursor, const std::string &pattern) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zscan(key, cursor, pattern, cb); });
-	}
-
-	std::future<reply>
-	client::zscan(const std::string &key, std::size_t cursor, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zscan(key, cursor, count, cb); });
-	}
-
-	std::future<reply>
-	client::zscan(const std::string &key, std::size_t cursor, const std::string &pattern, std::size_t count) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zscan(key, cursor, pattern, count, cb); });
-	}
-
-	std::future<reply>
-	client::zscore(const std::string &key, const std::string &member) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & { return zscore(key, member, cb); });
-	}
-
-	std::future<reply>
-	client::zunionstore(const std::string &destination, std::size_t numkeys, const std::vector<std::string> &keys,
-	                    const std::vector<std::size_t> weights, aggregate_method method) {
-		return exec_cmd([=](const reply_callback_t &cb) -> client & {
-				return zunionstore(destination, numkeys, keys, weights, method, cb);
-		});
-	}
+std::future<reply>
+client::xinfo_consumers(const std::string& key, const std::string& group_name) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xinfo_consumers(key, group_name, cb);
+  });
+}
+
+std::future<reply>
+client::xinfo_groups(const std::string& stream) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xinfo_groups(stream, cb);
+  });
+}
+
+std::future<reply>
+client::xinfo_stream(const std::string& stream) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xinfo_stream(stream, cb);
+  });
+}
+
+std::future<reply>
+client::xlen(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xlen(key, cb);
+  });
+}
+
+std::future<reply>
+client::xpending(const std::string& stream,
+  const std::string& group,
+  const xpending_options_t& options) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xpending(stream, group, options, cb);
+  });
+}
+
+std::future<reply>
+client::xrange(const std::string& stream, const range_options_t& range_args) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xrange(stream, range_args, cb);
+  });
+}
+
+std::future<reply>
+client::xreadgroup(const xreadgroup_options_t& a) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xreadgroup(a, cb);
+  });
+}
+
+std::future<reply>
+client::xread(const xread_options_t& a) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xread(a, cb);
+  });
+}
+
+std::future<reply>
+client::xrevrange(const std::string& key, const range_options_t& range_args) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xrevrange(key, range_args, cb);
+  });
+}
+
+std::future<reply>
+client::xtrim(const std::string& key, int max_len) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xtrim(key, max_len, cb);
+  });
+}
+std::future<reply>
+client::xtrim_approx(const std::string& key, int max_len) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return xtrim_approx(key, max_len, cb);
+  });
+}
+
+std::future<reply>
+client::zadd(const std::string& key, const std::vector<std::string>& options,
+  const std::multimap<std::string, std::string>& score_members) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zadd(key, options, score_members, cb); });
+}
+
+std::future<reply>
+client::zcard(const std::string& key) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zcard(key, cb); });
+}
+
+std::future<reply>
+client::zcount(const std::string& key, int min, int max) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zcount(key, min, max, cb); });
+}
+
+std::future<reply>
+client::zcount(const std::string& key, double min, double max) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zcount(key, min, max, cb); });
+}
+
+std::future<reply>
+client::zcount(const std::string& key, const std::string& min, const std::string& max) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zcount(key, min, max, cb); });
+}
+
+std::future<reply>
+client::zincrby(const std::string& key, int incr, const std::string& member) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zincrby(key, incr, member, cb); });
+}
+
+std::future<reply>
+client::zincrby(const std::string& key, double incr, const std::string& member) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zincrby(key, incr, member, cb); });
+}
+
+std::future<reply>
+client::zincrby(const std::string& key, const std::string& incr, const std::string& member) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zincrby(key, incr, member, cb); });
+}
+
+std::future<reply>
+client::zinterstore(const std::string& destination, std::size_t numkeys, const std::vector<std::string>& keys,
+  const std::vector<std::size_t> weights, aggregate_method method) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return zinterstore(destination, numkeys, keys, weights, method, cb);
+  });
+}
+
+std::future<reply>
+client::zlexcount(const std::string& key, int min, int max) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zlexcount(key, min, max, cb); });
+}
+
+std::future<reply>
+client::zlexcount(const std::string& key, double min, double max) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zlexcount(key, min, max, cb); });
+}
+
+std::future<reply>
+client::zlexcount(const std::string& key, const std::string& min, const std::string& max) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zlexcount(key, min, max, cb); });
+}
+
+std::future<reply>
+client::zpopmin(const std::string& key, int count) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zpopmin(key, count, cb); });
+}
+std::future<reply>
+client::zpopmax(const std::string& key, int count) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zpopmax(key, count, cb); });
+}
+
+std::future<reply>
+client::zrange(const std::string& key, int start, int stop, bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zrange(key, start, stop, withscores, cb); });
+}
+
+std::future<reply>
+client::zrange(const std::string& key, double start, double stop, bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zrange(key, start, stop, withscores, cb); });
+}
+
+std::future<reply>
+client::zrange(const std::string& key, const std::string& start, const std::string& stop, bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zrange(key, start, stop, withscores, cb); });
+}
+
+std::future<reply>
+client::zrangebylex(const std::string& key, int min, int max, bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zrangebylex(key, min, max, withscores, cb); });
+}
+
+std::future<reply>
+client::zrangebylex(const std::string& key, double min, double max, bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zrangebylex(key, min, max, withscores, cb); });
+}
+
+std::future<reply>
+client::zrangebylex(const std::string& key, const std::string& min, const std::string& max, bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zrangebylex(key, min, max, withscores, cb); });
+}
+
+std::future<reply>
+client::zrangebylex(const std::string& key, int min, int max, std::size_t offset, std::size_t count,
+  bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return zrangebylex(key, min, max, offset, count, withscores, cb);
+  });
+}
+
+std::future<reply>
+client::zrangebylex(const std::string& key, double min, double max, std::size_t offset, std::size_t count,
+  bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return zrangebylex(key, min, max, offset, count, withscores, cb);
+  });
+}
+
+std::future<reply>
+client::zrangebylex(const std::string& key, const std::string& min, const std::string& max, std::size_t offset,
+  std::size_t count, bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return zrangebylex(key, min, max, offset, count, withscores, cb);
+  });
+}
+
+std::future<reply>
+client::zrangebyscore(const std::string& key, int min, int max, bool withscores) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return zrangebyscore(key, min, max, withscores, cb); });
+}
+
+std::future<reply>
+client::zrangebyscore(const std::string& key, double min, double max, bool withscores) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return zrangebyscore(key, min, max, withscores, cb); });
+}
+
+std::future<reply>
+client::zrangebyscore(const std::string& key, const std::string& min, const std::string& max, bool withscores) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return zrangebyscore(key, min, max, withscores, cb); });
+}
+
+std::future<reply>
+client::zrangebyscore(const std::string& key, int min, int max, std::size_t offset, std::size_t count,
+  bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return zrangebyscore(key, min, max, offset, count, withscores, cb);
+  });
+}
+
+std::future<reply>
+client::zrangebyscore(const std::string& key, double min, double max, std::size_t offset, std::size_t count,
+  bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return zrangebyscore(key, min, max, offset, count, withscores, cb);
+  });
+}
+
+std::future<reply>
+client::zrangebyscore(const std::string& key, const std::string& min, const std::string& max, std::size_t offset,
+  std::size_t count, bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return zrangebyscore(key, min, max, offset, count, withscores, cb);
+  });
+}
+
+std::future<reply>
+client::zrank(const std::string& key, const std::string& member) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zrank(key, member, cb); });
+}
+
+std::future<reply>
+client::zrem(const std::string& key, const std::vector<std::string>& members) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zrem(key, members, cb); });
+}
+
+std::future<reply>
+client::zremrangebylex(const std::string& key, int min, int max) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zremrangebylex(key, min, max, cb); });
+}
+
+std::future<reply>
+client::zremrangebylex(const std::string& key, double min, double max) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zremrangebylex(key, min, max, cb); });
+}
+
+std::future<reply>
+client::zremrangebylex(const std::string& key, const std::string& min, const std::string& max) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zremrangebylex(key, min, max, cb); });
+}
+
+std::future<reply>
+client::zremrangebyrank(const std::string& key, int start, int stop) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zremrangebyrank(key, start, stop, cb); });
+}
+
+std::future<reply>
+client::zremrangebyrank(const std::string& key, double start, double stop) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zremrangebyrank(key, start, stop, cb); });
+}
+
+std::future<reply>
+client::zremrangebyrank(const std::string& key, const std::string& start, const std::string& stop) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zremrangebyrank(key, start, stop, cb); });
+}
+
+std::future<reply>
+client::zremrangebyscore(const std::string& key, int min, int max) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zremrangebyscore(key, min, max, cb); });
+}
+
+std::future<reply>
+client::zremrangebyscore(const std::string& key, double min, double max) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zremrangebyscore(key, min, max, cb); });
+}
+
+std::future<reply>
+client::zremrangebyscore(const std::string& key, const std::string& min, const std::string& max) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zremrangebyscore(key, min, max, cb); });
+}
+
+std::future<reply>
+client::zrevrange(const std::string& key, int start, int stop, bool withscores) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return zrevrange(key, start, stop, withscores, cb); });
+}
+
+std::future<reply>
+client::zrevrange(const std::string& key, double start, double stop, bool withscores) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return zrevrange(key, start, stop, withscores, cb); });
+}
+
+std::future<reply>
+client::zrevrange(const std::string& key, const std::string& start, const std::string& stop, bool withscores) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return zrevrange(key, start, stop, withscores, cb); });
+}
+
+std::future<reply>
+client::zrevrangebylex(const std::string& key, int max, int min, bool withscores) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return zrevrangebylex(key, max, min, withscores, cb); });
+}
+
+std::future<reply>
+client::zrevrangebylex(const std::string& key, double max, double min, bool withscores) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return zrevrangebylex(key, max, min, withscores, cb); });
+}
+
+std::future<reply>
+client::zrevrangebylex(const std::string& key, const std::string& max, const std::string& min, bool withscores) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return zrevrangebylex(key, max, min, withscores, cb); });
+}
+
+std::future<reply>
+client::zrevrangebylex(const std::string& key, int max, int min, std::size_t offset, std::size_t count,
+  bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return zrevrangebylex(key, max, min, offset, count, withscores, cb);
+  });
+}
+
+std::future<reply>
+client::zrevrangebylex(const std::string& key, double max, double min, std::size_t offset, std::size_t count,
+  bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return zrevrangebylex(key, max, min, offset, count, withscores, cb);
+  });
+}
+
+std::future<reply>
+client::zrevrangebylex(const std::string& key, const std::string& max, const std::string& min, std::size_t offset,
+  std::size_t count, bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return zrevrangebylex(key, max, min, offset, count, withscores, cb);
+  });
+}
+
+std::future<reply>
+client::zrevrangebyscore(const std::string& key, int max, int min, bool withscores) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return zrevrangebyscore(key, max, min, withscores, cb); });
+}
+
+std::future<reply>
+client::zrevrangebyscore(const std::string& key, double max, double min, bool withscores) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return zrevrangebyscore(key, max, min, withscores, cb); });
+}
+
+std::future<reply>
+client::zrevrangebyscore(const std::string& key, const std::string& max, const std::string& min, bool withscores) {
+  return exec_cmd(
+    [=](const reply_callback_t& cb) -> client& { return zrevrangebyscore(key, max, min, withscores, cb); });
+}
+
+std::future<reply>
+client::zrevrangebyscore(const std::string& key, int max, int min, std::size_t offset, std::size_t count,
+  bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return zrevrangebyscore(key, max, min, offset, count, withscores, cb);
+  });
+}
+
+std::future<reply>
+client::zrevrangebyscore(const std::string& key, double max, double min, std::size_t offset, std::size_t count,
+  bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return zrevrangebyscore(key, max, min, offset, count, withscores, cb);
+  });
+}
+
+std::future<reply>
+client::zrevrangebyscore(const std::string& key, const std::string& max, const std::string& min, std::size_t offset,
+  std::size_t count, bool withscores) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return zrevrangebyscore(key, max, min, offset, count, withscores, cb);
+  });
+}
+
+std::future<reply>
+client::zrevrank(const std::string& key, const std::string& member) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zrevrank(key, member, cb); });
+}
+
+std::future<reply>
+client::zscan(const std::string& key, std::size_t cursor) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zscan(key, cursor, cb); });
+}
+
+std::future<reply>
+client::zscan(const std::string& key, std::size_t cursor, const std::string& pattern) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zscan(key, cursor, pattern, cb); });
+}
+
+std::future<reply>
+client::zscan(const std::string& key, std::size_t cursor, std::size_t count) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zscan(key, cursor, count, cb); });
+}
+
+std::future<reply>
+client::zscan(const std::string& key, std::size_t cursor, const std::string& pattern, std::size_t count) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zscan(key, cursor, pattern, count, cb); });
+}
+
+std::future<reply>
+client::zscore(const std::string& key, const std::string& member) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& { return zscore(key, member, cb); });
+}
+
+std::future<reply>
+client::zunionstore(const std::string& destination, std::size_t numkeys, const std::vector<std::string>& keys,
+  const std::vector<std::size_t> weights, aggregate_method method) {
+  return exec_cmd([=](const reply_callback_t& cb) -> client& {
+    return zunionstore(destination, numkeys, keys, weights, method, cb);
+  });
+}
 
 } // namespace cpp_redis

--- a/sources/core/consumer.cpp
+++ b/sources/core/consumer.cpp
@@ -105,7 +105,7 @@ namespace cpp_redis {
 							// The reply is an array if valid
 							cpp_redis::xstream_reply s_reply(reply);
 							if (!s_reply.is_null()) {
-								__CPP_REDIS_LOG(2, "Stream " << s_reply)
+								__CPP_REDIS_LOG(info, "Stream " << s_reply)
 								for (const auto &stream : s_reply) {
 									for (auto &m : stream.Messages) {
 										if (m_should_read_pending.load())
@@ -136,7 +136,7 @@ namespace cpp_redis {
 															return response;
 													});
 										} catch (std::exception &exc) {
-											__CPP_REDIS_LOG(1,
+											__CPP_REDIS_LOG(warn,
 											                "Processing failed for message id: " + m.get_id() +
 											                "\nDetails: " + exc.what());
 											throw exc;

--- a/sources/core/consumer.cpp
+++ b/sources/core/consumer.cpp
@@ -29,134 +29,135 @@ using namespace std::placeholders;
 
 namespace cpp_redis {
 
-	consumer_client_container::consumer_client_container() : ack_client(), poll_client() {
-	}
+consumer_client_container::consumer_client_container()
+: ack_client(), poll_client() {
+}
 
-	consumer::consumer(std::string stream, std::string consumer, size_t max_concurrency)
-			: m_stream(std::move(stream)),
-			  m_name(std::move(consumer)),
-			  m_read_id("0"),
-			  m_block_sec(-1),
-			  m_max_concurrency(max_concurrency),
-			  m_read_count(static_cast<int>(max_concurrency)),
-			  m_callbacks() {
-		// Supply the dispatch queue a callback to notify the queue when it is at max capacity
-		m_dispatch_queue = dispatch_queue_ptr_t(
-				new dispatch_queue(stream, [&](size_t size) {
-						dispatch_changed_handler(size);
-				}, max_concurrency));
-		m_client = client_container_ptr_t(new consumer_client_container());
-	}
+consumer::consumer(std::string stream, std::string consumer, size_t max_concurrency)
+: m_stream(std::move(stream)), m_name(std::move(consumer)), m_read_id("0"), m_block_sec(-1), m_max_concurrency(max_concurrency), m_read_count(static_cast<int>(max_concurrency)), m_callbacks() {
+  // Supply the dispatch queue a callback to notify the queue when it is at max capacity
+  m_dispatch_queue = dispatch_queue_ptr_t(
+    new dispatch_queue(stream, [&](size_t size) {
+      dispatch_changed_handler(size);
+    },
+      max_concurrency));
+  m_client = client_container_ptr_t(new consumer_client_container());
+}
 
-	consumer &cpp_redis::consumer::subscribe(const std::string &group,
-	                                         const consumer_callback_t &consumer_callback,
-	                                         const acknowledgement_callback_t &acknowledgement_callback) {
-		m_callbacks.insert({group,
-		                    {consumer_callback,
-		                     acknowledgement_callback}});
-		return *this;
-	}
+consumer&
+cpp_redis::consumer::subscribe(const std::string& group,
+  const consumer_callback_t& consumer_callback,
+  const acknowledgement_callback_t& acknowledgement_callback) {
+  m_callbacks.insert({group,
+    {consumer_callback,
+      acknowledgement_callback}});
+  return *this;
+}
 
-	void consumer::dispatch_changed_handler(size_t size) {
-		if (size >= m_max_concurrency) {
-			dispatch_queue_full.store(true);
-			dispatch_queue_changed.notify_all();
-		}
-	}
+void
+consumer::dispatch_changed_handler(size_t size) {
+  if (size >= m_max_concurrency) {
+    dispatch_queue_full.store(true);
+    dispatch_queue_changed.notify_all();
+  }
+}
 
-	void consumer::connect(const std::string &host, size_t port, const connect_callback_t &connect_callback,
-	                       uint32_t timeout_ms, int32_t max_reconnects, uint32_t reconnect_interval_ms) {
-		m_client->ack_client.connect(host, port, connect_callback, timeout_ms, max_reconnects, reconnect_interval_ms);
-		m_client->poll_client.connect(host, port, connect_callback, timeout_ms, max_reconnects, reconnect_interval_ms);
-	}
+void
+consumer::connect(const std::string& host, size_t port, const connect_callback_t& connect_callback,
+  uint32_t timeout_ms, int32_t max_reconnects, uint32_t reconnect_interval_ms) {
+  m_client->ack_client.connect(host, port, connect_callback, timeout_ms, max_reconnects, reconnect_interval_ms);
+  m_client->poll_client.connect(host, port, connect_callback, timeout_ms, max_reconnects, reconnect_interval_ms);
+}
 
-	void consumer::auth(const std::string &password,
-	          const reply_callback_t &reply_callback) {
-		m_client->ack_client.auth(password, reply_callback);
-		m_client->poll_client.auth(password, reply_callback);
-	}
+void
+consumer::auth(const std::string& password,
+  const reply_callback_t& reply_callback) {
+  m_client->ack_client.auth(password, reply_callback);
+  m_client->poll_client.auth(password, reply_callback);
+}
 
-	consumer &consumer::commit() {
-		while (!is_ready) {
-			if (!is_ready) {
-				std::unique_lock<std::mutex> dispatch_lock(dispatch_queue_changed_mutex);
-				dispatch_queue_changed.wait(dispatch_lock, [&]() {
-						return !dispatch_queue_full.load();
-				});
-				m_read_count = static_cast<int>(m_max_concurrency - m_dispatch_queue->size());
-				poll();
-			}
-		}
-		return *this;
-	}
+consumer&
+consumer::commit() {
+  while (!is_ready) {
+    if (!is_ready) {
+      std::unique_lock<std::mutex> dispatch_lock(dispatch_queue_changed_mutex);
+      dispatch_queue_changed.wait(dispatch_lock, [&]() {
+        return !dispatch_queue_full.load();
+      });
+      m_read_count = static_cast<int>(m_max_concurrency - m_dispatch_queue->size());
+      poll();
+    }
+  }
+  return *this;
+}
 
-	void consumer::poll() {
-		for (auto &cb : m_callbacks) {
-			m_client->poll_client.xreadgroup(
-					{
-							cb.first, m_name,
-							{
-									{m_stream},
-									{m_read_id}
-							},
-							m_read_count, m_block_sec, false
-					},
-					[&](cpp_redis::reply &reply) {
-							// The reply is an array if valid
-							cpp_redis::xstream_reply s_reply(reply);
-							if (!s_reply.is_null()) {
-								__CPP_REDIS_LOG(info, "Stream " << s_reply)
-								for (const auto &stream : s_reply) {
-									for (auto &m : stream.Messages) {
-										if (m_should_read_pending.load())
-											m_read_id = m.get_id();
-										try {
-											m_dispatch_queue->dispatch(
-													m,
-													[&](const message_type &message) {
-															auto response = cb.second.consumer_callback(message);
+void
+consumer::poll() {
+  for (auto& cb : m_callbacks) {
+    m_client->poll_client.xreadgroup(
+                           {cb.first, m_name,
+                             {{m_stream},
+                               {m_read_id}},
+                             m_read_count, m_block_sec, false},
+                           [&](cpp_redis::reply& reply) {
+                             // The reply is an array if valid
+                             cpp_redis::xstream_reply s_reply(reply);
+                             if (!s_reply.is_null()) {
+                               __CPP_REDIS_LOG(info, "Stream " << s_reply)
+                               for (const auto& stream : s_reply) {
+                                 for (auto& m : stream.Messages) {
+                                   if (m_should_read_pending.load())
+                                     m_read_id = m.get_id();
+                                   try {
+                                     m_dispatch_queue->dispatch(
+                                       m,
+                                       [&](const message_type& message) {
+                                         auto response = cb.second.consumer_callback(message);
 
-															// add results to result stream
-															m_client->ack_client.xadd(
-																	m_stream+":results",
-																	"*",
-																	response);
+                                         // add results to result stream
+                                         m_client->ack_client.xadd(
+                                           m_stream + ":results",
+                                           "*",
+                                           response);
 
-															// acknowledge task completion
-															m_client->ack_client.xack(
-																	m_stream,
-																	cb.first,
-																	{message.get_id()},
-																	[&](const reply_t &r) {
-																			if (r.is_integer()) {
-																				auto ret_int = r.as_integer();
-																				cb.second.acknowledgement_callback(ret_int);
-																			}
-																	}).sync_commit();
-															return response;
-													});
-										} catch (std::exception &exc) {
-											__CPP_REDIS_LOG(warn,
-											                "Processing failed for message id: " + m.get_id() +
-											                "\nDetails: " + exc.what());
-											throw exc;
-										}
-									}
-								}
-							} else {
-								if (m_should_read_pending.load()) {
-									m_should_read_pending.store(false);
-									m_read_id = ">";
-									// Set to block infinitely
-									m_block_sec = 0;
-									// Set to read 1
-									m_read_count = 1;
-								}
-							}
-							return;
-					}).sync_commit(); //(std::chrono::milliseconds(1000));
-		}
-	}
+                                         // acknowledge task completion
+                                         m_client->ack_client.xack(
+                                                               m_stream,
+                                                               cb.first,
+                                                               {message.get_id()},
+                                                               [&](const reply_t& r) {
+                                                                 if (r.is_integer()) {
+                                                                   auto ret_int = r.as_integer();
+                                                                   cb.second.acknowledgement_callback(ret_int);
+                                                                 }
+                                                               })
+                                           .sync_commit();
+                                         return response;
+                                       });
+                                   }
+                                   catch (std::exception& exc) {
+                                     __CPP_REDIS_LOG(warn,
+                                       "Processing failed for message id: " + m.get_id() + "\nDetails: " + exc.what());
+                                     throw exc;
+                                   }
+                                 }
+                               }
+                             }
+                             else {
+                               if (m_should_read_pending.load()) {
+                                 m_should_read_pending.store(false);
+                                 m_read_id = ">";
+                                 // Set to block infinitely
+                                 m_block_sec = 0;
+                                 // Set to read 1
+                                 m_read_count = 1;
+                               }
+                             }
+                             return;
+                           })
+      .sync_commit(); //(std::chrono::milliseconds(1000));
+  }
+}
 
 
 } // namespace cpp_redis

--- a/sources/core/reply.cpp
+++ b/sources/core/reply.cpp
@@ -26,188 +26,189 @@
 
 namespace cpp_redis {
 
-	reply::reply()
-			: m_type(type::null) {}
+reply::reply()
+: m_type(type::null) {}
 
-	reply::reply(const std::string &value, string_type reply_type)
-			: m_type(static_cast<type>(reply_type)), m_str_val(value) {
-	}
+reply::reply(const std::string& value, string_type reply_type)
+: m_type(static_cast<type>(reply_type)), m_str_val(value) {
+}
 
-	reply::reply(int64_t value)
-			: m_type(type::integer), m_int_val(value) {}
+reply::reply(int64_t value)
+: m_type(type::integer), m_int_val(value) {}
 
-	reply::reply(const std::vector<reply> &rows)
-			: m_type(type::array), m_rows(rows) {}
+reply::reply(const std::vector<reply>& rows)
+: m_type(type::array), m_rows(rows) {}
 
-	reply::reply(reply &&other) noexcept {
-		m_type = other.m_type;
-		m_rows = std::move(other.m_rows);
-		m_str_val = std::move(other.m_str_val);
-		m_int_val = other.m_int_val;
-	}
+reply::reply(reply&& other) noexcept {
+  m_type    = other.m_type;
+  m_rows    = std::move(other.m_rows);
+  m_str_val = std::move(other.m_str_val);
+  m_int_val = other.m_int_val;
+}
 
-	optional_t<int64_t> reply::try_get_int() const {
-		if (is_integer())
-			return optional_t<int64_t>(m_int_val);
+optional_t<int64_t>
+reply::try_get_int() const {
+  if (is_integer())
+    return optional_t<int64_t>(m_int_val);
 
-		__CPP_REDIS_LOG(warn, "Reply is not an integer");
-		return {0};
-	}
+  __CPP_REDIS_LOG(warn, "Reply is not an integer");
+  return {0};
+}
 
-	reply &
-	reply::operator=(reply &&other) noexcept {
-		if (this != &other) {
-			m_type = other.m_type;
-			m_rows = std::move(other.m_rows);
-			m_str_val = std::move(other.m_str_val);
-			m_int_val = other.m_int_val;
-		}
+reply&
+reply::operator=(reply&& other) noexcept {
+  if (this != &other) {
+    m_type    = other.m_type;
+    m_rows    = std::move(other.m_rows);
+    m_str_val = std::move(other.m_str_val);
+    m_int_val = other.m_int_val;
+  }
 
-		return *this;
-	}
+  return *this;
+}
 
-	bool
-	reply::ok() const {
-		return !is_error();
-	}
+bool
+reply::ok() const {
+  return !is_error();
+}
 
-	bool
-	reply::ko() const {
-		return !ok();
-	}
+bool
+reply::ko() const {
+  return !ok();
+}
 
-	const std::string &
-	reply::error() const {
-		if (!is_error())
-			throw cpp_redis::redis_error("Reply is not an error");
+const std::string&
+reply::error() const {
+  if (!is_error())
+    throw cpp_redis::redis_error("Reply is not an error");
 
-		return as_string();
-	}
+  return as_string();
+}
 
-	reply::operator bool() const {
-		return !is_error() && !is_null();
-	}
+reply::operator bool() const {
+  return !is_error() && !is_null();
+}
 
-	void
-	reply::set() {
-		m_type = type::null;
-	}
+void
+reply::set() {
+  m_type = type::null;
+}
 
-	void
-	reply::set(const std::string &value, string_type reply_type) {
-		m_type = static_cast<type>(reply_type);
-		m_str_val = value;
-	}
+void
+reply::set(const std::string& value, string_type reply_type) {
+  m_type    = static_cast<type>(reply_type);
+  m_str_val = value;
+}
 
-	void
-	reply::set(int64_t value) {
-		m_type = type::integer;
-		m_int_val = value;
-	}
+void
+reply::set(int64_t value) {
+  m_type    = type::integer;
+  m_int_val = value;
+}
 
-	void
-	reply::set(const std::vector<reply> &rows) {
-		m_type = type::array;
-		m_rows = rows;
-	}
+void
+reply::set(const std::vector<reply>& rows) {
+  m_type = type::array;
+  m_rows = rows;
+}
 
-	reply &
-	reply::operator<<(const reply &reply) {
-		m_type = type::array;
-		m_rows.push_back(reply);
+reply&
+reply::operator<<(const reply& reply) {
+  m_type = type::array;
+  m_rows.push_back(reply);
 
-		return *this;
-	}
+  return *this;
+}
 
-	bool
-	reply::is_array() const {
-		return m_type == type::array;
-	}
+bool
+reply::is_array() const {
+  return m_type == type::array;
+}
 
-	bool
-	reply::is_string() const {
-		return is_simple_string() || is_bulk_string() || is_error();
-	}
+bool
+reply::is_string() const {
+  return is_simple_string() || is_bulk_string() || is_error();
+}
 
-	bool
-	reply::is_simple_string() const {
-		return m_type == type::simple_string;
-	}
+bool
+reply::is_simple_string() const {
+  return m_type == type::simple_string;
+}
 
-	bool
-	reply::is_bulk_string() const {
-		return m_type == type::bulk_string;
-	}
+bool
+reply::is_bulk_string() const {
+  return m_type == type::bulk_string;
+}
 
-	bool
-	reply::is_error() const {
-		return m_type == type::error;
-	}
+bool
+reply::is_error() const {
+  return m_type == type::error;
+}
 
-	bool
-	reply::is_integer() const {
-		return m_type == type::integer;
-	}
+bool
+reply::is_integer() const {
+  return m_type == type::integer;
+}
 
-	bool
-	reply::is_null() const {
-		return m_type == type::null;
-	}
+bool
+reply::is_null() const {
+  return m_type == type::null;
+}
 
-	const std::vector<reply> &
-	reply::as_array() const {
-		if (!is_array())
-			throw cpp_redis::redis_error("Reply is not an array");
+const std::vector<reply>&
+reply::as_array() const {
+  if (!is_array())
+    throw cpp_redis::redis_error("Reply is not an array");
 
-		return m_rows;
-	}
+  return m_rows;
+}
 
-	const std::string &
-	reply::as_string() const {
-		if (!is_string())
-			throw cpp_redis::redis_error("Reply is not a string");
+const std::string&
+reply::as_string() const {
+  if (!is_string())
+    throw cpp_redis::redis_error("Reply is not a string");
 
-		return m_str_val;
-	}
+  return m_str_val;
+}
 
-	int64_t
-	reply::as_integer() const {
-		if (!is_integer())
-			throw cpp_redis::redis_error("Reply is not an integer");
+int64_t
+reply::as_integer() const {
+  if (!is_integer())
+    throw cpp_redis::redis_error("Reply is not an integer");
 
-		return m_int_val;
-	}
+  return m_int_val;
+}
 
-	reply::type
-	reply::get_type() const {
-		return m_type;
-	}
+reply::type
+reply::get_type() const {
+  return m_type;
+}
 
 } // namespace cpp_redis
 
-std::ostream &
-operator<<(std::ostream &os, const cpp_redis::reply &reply) {
-	switch (reply.get_type()) {
-		case cpp_redis::reply::type::error:
-			os << reply.error();
-			break;
-		case cpp_redis::reply::type::bulk_string:
-			os << reply.as_string();
-			break;
-		case cpp_redis::reply::type::simple_string:
-			os << reply.as_string();
-			break;
-		case cpp_redis::reply::type::null:
-			os << std::string("(nil)");
-			break;
-		case cpp_redis::reply::type::integer:
-			os << reply.as_integer();
-			break;
-		case cpp_redis::reply::type::array:
-			for (const auto &item : reply.as_array())
-				os << item;
-			break;
-	}
+std::ostream&
+operator<<(std::ostream& os, const cpp_redis::reply& reply) {
+  switch (reply.get_type()) {
+  case cpp_redis::reply::type::error:
+    os << reply.error();
+    break;
+  case cpp_redis::reply::type::bulk_string:
+    os << reply.as_string();
+    break;
+  case cpp_redis::reply::type::simple_string:
+    os << reply.as_string();
+    break;
+  case cpp_redis::reply::type::null:
+    os << std::string("(nil)");
+    break;
+  case cpp_redis::reply::type::integer:
+    os << reply.as_integer();
+    break;
+  case cpp_redis::reply::type::array:
+    for (const auto& item : reply.as_array())
+      os << item;
+    break;
+  }
 
-	return os;
+  return os;
 }

--- a/sources/core/reply.cpp
+++ b/sources/core/reply.cpp
@@ -50,7 +50,7 @@ namespace cpp_redis {
 		if (is_integer())
 			return optional_t<int64_t>(m_int_val);
 
-		__CPP_REDIS_LOG(1, "Reply is not an integer");
+		__CPP_REDIS_LOG(warn, "Reply is not an integer");
 		return {0};
 	}
 

--- a/sources/core/subscriber.cpp
+++ b/sources/core/subscriber.cpp
@@ -97,10 +97,10 @@ subscriber::connect(
   __CPP_REDIS_LOG(debug, "cpp_redis::subscriber attempts to connect");
 
   //! Save for auto reconnects
-  m_redis_server             = host;
-  m_redis_port               = port;
-  m_connect_callback         = connect_callback;
-  m_max_reconnects           = max_reconnects;
+  m_redis_server          = host;
+  m_redis_port            = port;
+  m_connect_callback      = connect_callback;
+  m_max_reconnects        = max_reconnects;
   m_reconnect_interval_ms = reconnect_interval_ms;
 
   //! notify start
@@ -167,7 +167,7 @@ subscriber::client_setname(const std::string& name, const reply_callback_t& repl
   // commands on reconnecting.  This makes it impossible to do reliably in the application
   // layer as opposed to in the subscriber itself for reconnects.  re_client_setname will
   // send the command at reconnect time.
-  m_client_name = name;
+  m_client_name                   = name;
   m_client_setname_reply_callback = reply_callback;
 
   m_client.send({"CLIENT", "SETNAME", name});

--- a/sources/core/types.cpp
+++ b/sources/core/types.cpp
@@ -24,116 +24,123 @@
 
 namespace cpp_redis {
 
-	xmessage::xmessage(const reply_t &data) {
-		if (data.is_array()) {
-			auto k = data.as_array().front();
-			auto v = data.as_array().back();
-			if (k.is_string()) {
-				set_id(k.as_string());
-			}
-			if (v.is_array()) {
-				auto val_array = v.as_array();
-				std::string key;
-				int i = 1;
-				for (auto &val : val_array) {
-					if (i%2!=0) {
-						key = val.as_string();
-					} else {
-						push(key, val);
-					}
-					i++;
-				}
-				//push(v.as_array().begin(), v.as_array().end());
-			}
-		}
-	}
+xmessage::xmessage(const reply_t& data) {
+  if (data.is_array()) {
+    auto k = data.as_array().front();
+    auto v = data.as_array().back();
+    if (k.is_string()) {
+      set_id(k.as_string());
+    }
+    if (v.is_array()) {
+      auto val_array = v.as_array();
+      std::string key;
+      int i = 1;
+      for (auto& val : val_array) {
+        if (i % 2 != 0) {
+          key = val.as_string();
+        }
+        else {
+          push(key, val);
+        }
+        i++;
+      }
+      //push(v.as_array().begin(), v.as_array().end());
+    }
+  }
+}
 
-	xstream::xstream(const reply &data) {
-		if (data.is_array()) {
-			auto s = data.as_array().front();
-			if (s.is_string()) {
-				Stream = s.as_string();
-			}
-			auto m = data.as_array().back();
-			if (m.is_array()) {
-				for (auto &sm : m.as_array()) {
-					Messages.emplace_back(xmessage(sm));
-				}
-			}
-		}
-	}
+xstream::xstream(const reply& data) {
+  if (data.is_array()) {
+    auto s = data.as_array().front();
+    if (s.is_string()) {
+      Stream = s.as_string();
+    }
+    auto m = data.as_array().back();
+    if (m.is_array()) {
+      for (auto& sm : m.as_array()) {
+        Messages.emplace_back(xmessage(sm));
+      }
+    }
+  }
+}
 
-	std::ostream &operator<<(std::ostream &os, const xmessage &xm) {
-		os << "\n\t\t\"id\": " << xm.get_id() << "\n\t\t\"values\": {";
-		for (auto &v : xm.get_values()) {
-			auto re = v.second;
-			os << "\n\t\t\t\"" << v.first << "\": " << re.as_string() << ",";
-		}
-		os << "\n\t\t}";
-		return os;
-	}
+std::ostream&
+operator<<(std::ostream& os, const xmessage& xm) {
+  os << "\n\t\t\"id\": " << xm.get_id() << "\n\t\t\"values\": {";
+  for (auto& v : xm.get_values()) {
+    auto re = v.second;
+    os << "\n\t\t\t\"" << v.first << "\": " << re.as_string() << ",";
+  }
+  os << "\n\t\t}";
+  return os;
+}
 
-	std::string operator<<(const std::string& is, const xmessage &xs) {
-		std::stringstream output;
-		output << is;
-		output << xs;
-		return output.str();
-	}
+std::string
+operator<<(const std::string& is, const xmessage& xs) {
+  std::stringstream output;
+  output << is;
+  output << xs;
+  return output.str();
+}
 
-	xmessage::xmessage() = default;
+xmessage::xmessage() = default;
 
-	std::ostream &operator<<(std::ostream &os, const xstream &xs) {
-		os << "{\n\t\"stream\": " << xs.Stream << "\n\t\"messages\": [";
-		for (auto &m : xs.Messages) {
-			os << m;
-		}
-		os << "\n\t]\n}";
-		return os;
-	}
+std::ostream&
+operator<<(std::ostream& os, const xstream& xs) {
+  os << "{\n\t\"stream\": " << xs.Stream << "\n\t\"messages\": [";
+  for (auto& m : xs.Messages) {
+    os << m;
+  }
+  os << "\n\t]\n}";
+  return os;
+}
 
-	std::string operator<<(const std::string& is, const xstream &xs) {
-		std::stringstream output;
-		output << is;
-		output << xs;
-		return output.str();
-	}
+std::string
+operator<<(const std::string& is, const xstream& xs) {
+  std::stringstream output;
+  output << is;
+  output << xs;
+  return output.str();
+}
 
-	xstream_reply::xstream_reply(const reply &data) {
-		if (data.is_array()) {
-			for (auto &d : data.as_array()) {
-				emplace_back(xstream(d));
-			}
-		}
-	}
+xstream_reply::xstream_reply(const reply& data) {
+  if (data.is_array()) {
+    for (auto& d : data.as_array()) {
+      emplace_back(xstream(d));
+    }
+  }
+}
 
-	std::ostream &operator<<(std::ostream &os, const xstream_reply &xs) {
-		for (auto &x : xs) {
-			os << x;
-		}
-		return os;
-	}
+std::ostream&
+operator<<(std::ostream& os, const xstream_reply& xs) {
+  for (auto& x : xs) {
+    os << x;
+  }
+  return os;
+}
 
-	std::string operator<<(const std::string& is, const xstream_reply &xs) {
-		std::stringstream output;
-		output << is;
-		output << xs;
-		return output.str();
-	}
+std::string
+operator<<(const std::string& is, const xstream_reply& xs) {
+  std::stringstream output;
+  output << is;
+  output << xs;
+  return output.str();
+}
 
-	xinfo_reply::xinfo_reply(const cpp_redis::reply &data) {
-		if ( data.is_array()) {
-			auto da = data.as_array();
-			//reply z = da[0];
-			//std::cout << data.as_string() << std::endl;
-			Length = da[1].as_integer();
-			RadixTreeKeys = da[3].as_integer();
-			RadixTreeNodes = da[5].as_integer();
-			Groups = da[7].as_integer();
-			LastGeneratedId = da[9].as_string();
-			xmessage_t x((da[11]));
-			FirstEntry = x;
-			xmessage_t y(da[13]);
-			LastEntry = y;
-		}
-	}
+xinfo_reply::xinfo_reply(const cpp_redis::reply& data) {
+  if (data.is_array()) {
+    auto da = data.as_array();
+    //reply z = da[0];
+    //std::cout << data.as_string() << std::endl;
+    Length          = da[1].as_integer();
+    RadixTreeKeys   = da[3].as_integer();
+    RadixTreeNodes  = da[5].as_integer();
+    Groups          = da[7].as_integer();
+    LastGeneratedId = da[9].as_string();
+    xmessage_t x((da[11]));
+    FirstEntry = x;
+    xmessage_t y(da[13]);
+    LastEntry = y;
+  }
+}
 } // namespace cpp_redis

--- a/sources/core/types.cpp
+++ b/sources/core/types.cpp
@@ -73,6 +73,13 @@ namespace cpp_redis {
 		return os;
 	}
 
+	std::string operator<<(const std::string& is, const xmessage &xs) {
+		std::stringstream output;
+		output << is;
+		output << xs;
+		return output.str();
+	}
+
 	xmessage::xmessage() = default;
 
 	std::ostream &operator<<(std::ostream &os, const xstream &xs) {
@@ -82,6 +89,13 @@ namespace cpp_redis {
 		}
 		os << "\n\t]\n}";
 		return os;
+	}
+
+	std::string operator<<(const std::string& is, const xstream &xs) {
+		std::stringstream output;
+		output << is;
+		output << xs;
+		return output.str();
 	}
 
 	xstream_reply::xstream_reply(const reply &data) {
@@ -97,6 +111,13 @@ namespace cpp_redis {
 			os << x;
 		}
 		return os;
+	}
+
+	std::string operator<<(const std::string& is, const xstream_reply &xs) {
+		std::stringstream output;
+		output << is;
+		output << xs;
+		return output.str();
 	}
 
 	xinfo_reply::xinfo_reply(const cpp_redis::reply &data) {

--- a/sources/network/redis_connection.cpp
+++ b/sources/network/redis_connection.cpp
@@ -32,197 +32,197 @@
 
 namespace cpp_redis {
 
-	namespace network {
+namespace network {
 
 #ifndef __CPP_REDIS_USE_CUSTOM_TCP_CLIENT
 
-		redis_connection::redis_connection()
-				: redis_connection(std::make_shared<tcp_client>()) {
-		}
+redis_connection::redis_connection()
+: redis_connection(std::make_shared<tcp_client>()) {
+}
 
 #endif /* __CPP_REDIS_USE_CUSTOM_TCP_CLIENT */
 
-		redis_connection::redis_connection(const std::shared_ptr<tcp_client_iface> &client)
-				: m_client(client), m_reply_callback(nullptr), m_disconnection_handler(nullptr) {
-			__CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection created");
-		}
+redis_connection::redis_connection(const std::shared_ptr<tcp_client_iface>& client)
+: m_client(client), m_reply_callback(nullptr), m_disconnection_handler(nullptr) {
+  __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection created");
+}
 
-		redis_connection::~redis_connection() {
-			m_client->disconnect(true);
-			__CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection destroyed");
-		}
+redis_connection::~redis_connection() {
+  m_client->disconnect(true);
+  __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection destroyed");
+}
 
-		void
-		redis_connection::connect(const std::string &host, std::size_t port,
-		                          const disconnection_handler_t &client_disconnection_handler,
-		                          const reply_callback_t &client_reply_callback,
-		                          std::uint32_t timeout_ms) {
-			try {
-				__CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection attempts to connect");
+void
+redis_connection::connect(const std::string& host, std::size_t port,
+  const disconnection_handler_t& client_disconnection_handler,
+  const reply_callback_t& client_reply_callback,
+  std::uint32_t timeout_ms) {
+  try {
+    __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection attempts to connect");
 
-/**
+    /**
  * connect client
  */
-				m_client->connect(host, (uint32_t) port, timeout_ms);
-				m_client->set_on_disconnection_handler(std::bind(&redis_connection::tcp_client_disconnection_handler, this));
+    m_client->connect(host, (uint32_t) port, timeout_ms);
+    m_client->set_on_disconnection_handler(std::bind(&redis_connection::tcp_client_disconnection_handler, this));
 
-/**
+    /**
  * start to read asynchronously
  */
-				tcp_client_iface::read_request request = {__CPP_REDIS_READ_SIZE,
-				                                          std::bind(&redis_connection::tcp_client_receive_handler, this,
-				                                                    std::placeholders::_1)};
-				m_client->async_read(request);
+    tcp_client_iface::read_request request = {__CPP_REDIS_READ_SIZE,
+      std::bind(&redis_connection::tcp_client_receive_handler, this,
+        std::placeholders::_1)};
+    m_client->async_read(request);
 
-				__CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection connected");
-			}
-			catch (const std::exception &e) {
-				__CPP_REDIS_LOG(error, std::string("cpp_redis::network::redis_connection ") + e.what());
-				throw redis_error(e.what());
-			}
+    __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection connected");
+  }
+  catch (const std::exception& e) {
+    __CPP_REDIS_LOG(error, std::string("cpp_redis::network::redis_connection ") + e.what());
+    throw redis_error(e.what());
+  }
 
-			m_reply_callback = client_reply_callback;
-			m_disconnection_handler = client_disconnection_handler;
-		}
+  m_reply_callback        = client_reply_callback;
+  m_disconnection_handler = client_disconnection_handler;
+}
 
-		void
-		redis_connection::disconnect(bool wait_for_removal) {
-			__CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection attempts to disconnect");
+void
+redis_connection::disconnect(bool wait_for_removal) {
+  __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection attempts to disconnect");
 
-/**
+  /**
  * close connection
  */
-			m_client->disconnect(wait_for_removal);
+  m_client->disconnect(wait_for_removal);
 
-/**
+  /**
  * clear buffer
  */
-			m_buffer.clear();
-/**
+  m_buffer.clear();
+  /**
  * clear builder
  */
-			m_builder.reset();
+  m_builder.reset();
 
-			__CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection disconnected");
-		}
+  __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection disconnected");
+}
 
-		bool
-		redis_connection::is_connected() const {
-			return m_client->is_connected();
-		}
+bool
+redis_connection::is_connected() const {
+  return m_client->is_connected();
+}
 
-		std::string
-		redis_connection::build_command(const std::vector<std::string> &redis_cmd) {
-			std::string cmd = "*" + std::to_string(redis_cmd.size()) + "\r\n";
+std::string
+redis_connection::build_command(const std::vector<std::string>& redis_cmd) {
+  std::string cmd = "*" + std::to_string(redis_cmd.size()) + "\r\n";
 
-			for (const auto &cmd_part : redis_cmd)
-				cmd += "$" + std::to_string(cmd_part.length()) + "\r\n" + cmd_part + "\r\n";
+  for (const auto& cmd_part : redis_cmd)
+    cmd += "$" + std::to_string(cmd_part.length()) + "\r\n" + cmd_part + "\r\n";
 
-			return cmd;
-		}
+  return cmd;
+}
 
-		redis_connection &
-		redis_connection::send(const std::vector<std::string> &redis_cmd) {
-			std::lock_guard<std::mutex> lock(m_buffer_mutex);
+redis_connection&
+redis_connection::send(const std::vector<std::string>& redis_cmd) {
+  std::lock_guard<std::mutex> lock(m_buffer_mutex);
 
-			m_buffer += build_command(redis_cmd);
-			__CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection stored new command in the send buffer");
+  m_buffer += build_command(redis_cmd);
+  __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection stored new command in the send buffer");
 
-			return *this;
-		}
+  return *this;
+}
 
-		/**
+/**
 		 * commit pipelined transaction
 		 */
-		redis_connection &
-		redis_connection::commit() {
-			std::lock_guard<std::mutex> lock(m_buffer_mutex);
+redis_connection&
+redis_connection::commit() {
+  std::lock_guard<std::mutex> lock(m_buffer_mutex);
 
-			/**
+  /**
 			 * ensure buffer is cleared
 			 */
-			__CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection attempts to send pipelined commands");
-			std::string buffer = std::move(m_buffer);
+  __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection attempts to send pipelined commands");
+  std::string buffer = std::move(m_buffer);
 
-			try {
-				tcp_client_iface::write_request request = {std::vector<char>{buffer.begin(), buffer.end()}, nullptr};
-				m_client->async_write(request);
-			}
-			catch (const std::exception &e) {
-				__CPP_REDIS_LOG(error, std::string("cpp_redis::network::redis_connection ") + e.what());
-				throw redis_error(e.what());
-			}
+  try {
+    tcp_client_iface::write_request request = {std::vector<char>{buffer.begin(), buffer.end()}, nullptr};
+    m_client->async_write(request);
+  }
+  catch (const std::exception& e) {
+    __CPP_REDIS_LOG(error, std::string("cpp_redis::network::redis_connection ") + e.what());
+    throw redis_error(e.what());
+  }
 
-			__CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection sent pipelined commands");
+  __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection sent pipelined commands");
 
-			return *this;
-		}
+  return *this;
+}
 
-		void
-		redis_connection::call_disconnection_handler() {
-			if (m_disconnection_handler) {
-				__CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection calls disconnection handler");
-				m_disconnection_handler(*this);
-			}
-		}
+void
+redis_connection::call_disconnection_handler() {
+  if (m_disconnection_handler) {
+    __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection calls disconnection handler");
+    m_disconnection_handler(*this);
+  }
+}
 
-		void
-		redis_connection::tcp_client_receive_handler(const tcp_client_iface::read_result &result) {
-			if (!result.success) { return; }
+void
+redis_connection::tcp_client_receive_handler(const tcp_client_iface::read_result& result) {
+  if (!result.success) { return; }
 
-			try {
-				__CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection receives packet, attempts to build reply");
-				m_builder << std::string(result.buffer.begin(), result.buffer.end());
-			}
-			catch (const redis_error &) {
-				__CPP_REDIS_LOG(error,
-				                "cpp_redis::network::redis_connection could not build reply (invalid format), disconnecting");
-				call_disconnection_handler();
-				return;
-			}
+  try {
+    __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection receives packet, attempts to build reply");
+    m_builder << std::string(result.buffer.begin(), result.buffer.end());
+  }
+  catch (const redis_error&) {
+    __CPP_REDIS_LOG(error,
+      "cpp_redis::network::redis_connection could not build reply (invalid format), disconnecting");
+    call_disconnection_handler();
+    return;
+  }
 
-			while (m_builder.reply_available()) {
-				__CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection reply fully built");
+  while (m_builder.reply_available()) {
+    __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection reply fully built");
 
-				auto reply = m_builder.get_front();
-				m_builder.pop_front();
+    auto reply = m_builder.get_front();
+    m_builder.pop_front();
 
-				if (m_reply_callback) {
-					__CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection executes reply callback");
-					m_reply_callback(*this, reply);
-				}
-			}
+    if (m_reply_callback) {
+      __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection executes reply callback");
+      m_reply_callback(*this, reply);
+    }
+  }
 
-			try {
-				tcp_client_iface::read_request request = {__CPP_REDIS_READ_SIZE,
-				                                          std::bind(&redis_connection::tcp_client_receive_handler, this,
-				                                                    std::placeholders::_1)};
-				m_client->async_read(request);
-			}
-			catch (const std::exception &) {
-/**
+  try {
+    tcp_client_iface::read_request request = {__CPP_REDIS_READ_SIZE,
+      std::bind(&redis_connection::tcp_client_receive_handler, this,
+        std::placeholders::_1)};
+    m_client->async_read(request);
+  }
+  catch (const std::exception&) {
+    /**
  * Client disconnected in the meantime
  */
-			}
-		}
+  }
+}
 
-		void
-		redis_connection::tcp_client_disconnection_handler() {
-			__CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection has been disconnected");
-/**
+void
+redis_connection::tcp_client_disconnection_handler() {
+  __CPP_REDIS_LOG(debug, "cpp_redis::network::redis_connection has been disconnected");
+  /**
  * clear buffer
  */
-			m_buffer.clear();
-/**
+  m_buffer.clear();
+  /**
  * clear builder
  */
-			m_builder.reset();
-/**
+  m_builder.reset();
+  /**
  * call disconnection handler
  */
-			call_disconnection_handler();
-		}
+  call_disconnection_handler();
+}
 
-	} // namespace network
+} // namespace network
 
 } // namespace cpp_redis


### PR DESCRIPTION
## Status
- ✅: Build & Test (see [Contributing - 4. Build the entire library](https://github.com/cpp-redis/cpp_redis/blob/master/CONTRIBUTING.md#4-build-the-entire-library))
- ✅/❓: `clang-format` (see [Contributing - 5. Code your changes](https://github.com/cpp-redis/cpp_redis/blob/master/CONTRIBUTING.md#5-code-your-changes))  
  - ✅: Successfully executed `clang_format.sh`
  - ❓: It looks like the style specified in `.clang-format` doesn't match the actual code style.
    -> Please check and revert [e7b130f70fcc0e4d25943a3469b13f26b85426df](https://github.com/dkkeller/cpp_redis/commit/e7b130f70fcc0e4d25943a3469b13f26b85426df), if code style should not be applied.

## Fixes
- `Code`: Fixed `__CPP_REDIS_LOG` calls with log level as int instead of type. 
- `Code`: `operator<<` can now be used within `__CPP_REDIS_LOG`
- `Docu`: Fixed binary paths for subscriber and client @ [CONTRIBUTING.md](https://github.com/dkkeller/cpp_redis/blob/master/CONTRIBUTING.md#4-build-the-entire-library)

## Improvements
- Make sure the correct clang-format style file is used @ `clang_format.sh`