### PR TITLE
Fix Starlark function syntax

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-cpp_redis_repositories:
+def cpp_redis_repositories():
   """Add external dependencies to the workspace."""
   maybe(
     http_archive,


### PR DESCRIPTION
It's no longer working with the latest version of Bazel. Tested by adding cpp_redis dependency to another repository's WORKSPACE and calling `cpp_redis_repositories()`, then executing `bazel build @com_github_cpp_redis_cpp_redis//:cpp_redis`.