### PR TITLE
Fix bazel 3.3.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,8 @@
-new_http_archive(
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
     name = "gtest",
-    build_file = "BUILD.gtest",
+    build_file = "@//:BUILD.gtest",
     sha256 = "f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf",
     strip_prefix = "googletest-release-1.8.0",
     url = "https://github.com/google/googletest/archive/release-1.8.0.zip",

--- a/examples/cpp_redis_client.cpp
+++ b/examples/cpp_redis_client.cpp
@@ -22,13 +22,17 @@
 #include <string>
 #include <cpp_redis/cpp_redis>
 #include <cpp_redis/misc/macro.hpp>
+#if _WIN32
 #include "winsock_initializer.h"
+#endif
 
 #define ENABLE_SESSION = 1
 
 int
 main(void) {
+#if _WIN32
 	winsock_initializer winsock_init;
+#endif
 	//! Enable logging
 	cpp_redis::active_logger = std::unique_ptr<cpp_redis::logger>(new cpp_redis::logger);
 

--- a/examples/cpp_redis_future_client.cpp
+++ b/examples/cpp_redis_future_client.cpp
@@ -23,11 +23,15 @@
 #include <cpp_redis/cpp_redis>
 
 #include <iostream>
+#if _WIN32
 #include "winsock_initializer.h"
+#endif
 
 int
 main(void) {
+#if _WIN32
   winsock_initializer winsock_init;
+#endif
 
   //! Enable logging
   cpp_redis::active_logger = std::unique_ptr<cpp_redis::logger>(new cpp_redis::logger);

--- a/examples/cpp_redis_high_availability_client.cpp
+++ b/examples/cpp_redis_high_availability_client.cpp
@@ -23,11 +23,15 @@
 #include <cpp_redis/cpp_redis>
 
 #include <iostream>
+#if _WIN32
 #include "winsock_initializer.h"
+#endif
 
 int
 main(void) {
+#if _WIN32
   winsock_initializer winsock_init;
+#endif
   //! Enable logging
   cpp_redis::active_logger = std::unique_ptr<cpp_redis::logger>(new cpp_redis::logger);
 

--- a/examples/cpp_redis_kill.cpp
+++ b/examples/cpp_redis_kill.cpp
@@ -24,11 +24,15 @@
 
 #include <iostream>
 #include <sstream>
+#if _WIN32
 #include "winsock_initializer.h"
+#endif
 
 int
 main(void) {
+#if _WIN32
   winsock_initializer winsock_init;
+#endif
   cpp_redis::client client;
 
   client.connect("127.0.0.1", 6379, [](const std::string& host, std::size_t port, cpp_redis::connect_state status) {

--- a/examples/cpp_redis_multi_exec.cpp
+++ b/examples/cpp_redis_multi_exec.cpp
@@ -1,12 +1,16 @@
 // The MIT License (MIT)
 
+#if _WIN32
 #include "winsock_initializer.h"
+#endif
 #include <cpp_redis/cpp_redis>
 #include <string>
 
 int
 main(void) {
+#if _WIN32
   winsock_initializer winsock_init;
+#endif
   cpp_redis::client client;
 
   client.connect("127.0.0.1", 6379,

--- a/examples/cpp_redis_subscriber.cpp
+++ b/examples/cpp_redis_subscriber.cpp
@@ -27,7 +27,9 @@
 #include <iostream>
 #include <mutex>
 #include <signal.h>
+#if _WIN32
 #include "winsock_initializer.h"
+#endif
 
 std::condition_variable should_exit;
 
@@ -38,7 +40,9 @@ sigint_handler(int) {
 
 int
 main(void) {
+#if _WIN32
   winsock_initializer winsock_init;
+#endif
   //! Enable logging
   cpp_redis::active_logger = std::unique_ptr<cpp_redis::logger>(new cpp_redis::logger);
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-cpp_redis_repositories:
+def cpp_redis_repositories():
   """Add external dependencies to the workspace."""
   maybe(
     http_archive,


### PR DESCRIPTION
In its current state, the repository does not build with the latest version of bazel (3.3.0) nor can be included as a dependency.
Error shown below:
Building the project
<img width="1436" alt="Captura de Tela 2020-06-28 às 17 24 01" src="https://user-images.githubusercontent.com/16000613/85958241-7b07c480-b96a-11ea-9a6d-f624eb5a0549.png">
As a dependency
<img width="1291" alt="Captura de Tela 2020-06-28 às 18 11 01" src="https://user-images.githubusercontent.com/16000613/85958291-d9cd3e00-b96a-11ea-9478-85c510b2aeee.png">


This PR fix the syntax in `repositories.bzl` and `WORKSPACE` to make it buildable. It also adds the conditional include and use of winsocket for _WIN32 platforms so the project is also buildable in other platforms (currently tested in MacOS Catalina).