### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -55,7 +55,7 @@ foreach(EXAMPLE IN ITEMS ${EXAMPLES})
   # executable
   ###
   add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
-  target_link_libraries(${EXAMPLE} cpp_redis)
+  target_link_libraries(${EXAMPLE} cpp_redis tacopie)
 
   ###
   # link libs


### PR DESCRIPTION
tacopie is missing a reference to the ‘target_link_libraries’