### PR TITLE
Fix memory corruption

### DIFF
--- a/sources/core/client.cpp
+++ b/sources/core/client.cpp
@@ -302,7 +302,8 @@ namespace cpp_redis {
 
 				m_sync_condvar.notify_all();
 		});
-		t.detach();
+		// t.detach();
+		t.join();
 	}
 
 	void


### PR DESCRIPTION
when destuct client object, callback clear thread not join.