### PR TITLE
fix example cc_binary:example_cpp_redis_client build failed

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -73,7 +73,10 @@ cc_binary(
 
 cc_binary(
     name = "example_cpp_redis_client",
-    srcs = ["examples/cpp_redis_client.cpp"],
+    srcs = [
+        "examples/cpp_redis_client.cpp",
+        "examples/winsock_initializer.h"
+    ],
     # TODO (steple): For windows, link ws2_32 instead.
     linkopts = ["-lpthread"],
     deps = ["cpp_redis"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,6 @@
-new_http_archive(
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
     name = "gtest",
     build_file = "BUILD.gtest",
     sha256 = "f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,4 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
+new_http_archive(
     name = "gtest",
     build_file = "BUILD.gtest",
     sha256 = "f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf",

--- a/examples/cpp_redis_client.cpp
+++ b/examples/cpp_redis_client.cpp
@@ -22,12 +22,11 @@
 #include <string>
 #include <cpp_redis/cpp_redis>
 #include <cpp_redis/misc/macro.hpp>
-#include "winsock_initializer.h"
+#include "examples/winsock_initializer.h"
 
 #define ENABLE_SESSION = 1
 
-int
-main(void) {
+int main(void) {
 	winsock_initializer winsock_init;
 	//! Enable logging
 	cpp_redis::active_logger = std::unique_ptr<cpp_redis::logger>(new cpp_redis::logger);


### PR DESCRIPTION
hi , I use bazel tool to build cc_binary:example_cpp_redis_client,   but it was faild.  i fix this bug.